### PR TITLE
Feature/shiftlag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ mcversion=1.7.10
 forgeversion=10.13.4.1614-1.7.10
 version_major=4
 version_minor=2
-version_patch=20
+version_patch=21

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -77,6 +77,12 @@ public class Config {
 	// Performance
 	public static boolean enableBackpackResupply = true;
 
+    // Optimization
+    public static boolean enableCraftingTimeout = true;
+    public static int craftingTimeout = 200; // Time given in ms
+    public static boolean cacheWorktableRecipes = true;
+    public static boolean promoteWorktableRecipesToFrontOfGlobalRecipemap = true;
+
 	// Customization
 	private static boolean craftingBronzeEnabled = true;
 
@@ -214,6 +220,11 @@ public class Config {
 		dungeonLootRare = configCommon.getBooleanLocalized("difficulty", "loot.rare", dungeonLootRare);
 
 		enableBackpackResupply = configCommon.getBooleanLocalized("performance", "backpacks.resupply", enableBackpackResupply);
+
+        enableCraftingTimeout = configCommon.getBooleanLocalized("optimization","enable.crafting.timeout", enableCraftingTimeout);
+        craftingTimeout = configCommon.getIntLocalized("optimization","crafting.timeout",craftingTimeout, 50, 2000 ); // min 50ms, default 200ms, max 2000 ms. Integer.MAX_VALUE is ~ 2100 ms because of multiplication by 1,000,000
+        cacheWorktableRecipes = configCommon.getBooleanLocalized("optimization","cache.worktable.recipes", cacheWorktableRecipes);
+        promoteWorktableRecipesToFrontOfGlobalRecipemap = configCommon.getBooleanLocalized("optimization","promote.worktable.recipes",promoteWorktableRecipesToFrontOfGlobalRecipemap);
 
 		// move legacy mail property
 		configCommon.moveProperty("tweaks.gui", "mail.alert", "tweaks.gui.mail.alert");

--- a/src/main/java/forestry/core/recipes/RecipeUtil.java
+++ b/src/main/java/forestry/core/recipes/RecipeUtil.java
@@ -153,11 +153,9 @@ public abstract class RecipeUtil {
 		}
 
 		List<ItemStack> matchingRecipes = new ArrayList<>();
-        List<int> matchingIndex=new ArrayList();
-        List matchingRecipeMap = new ArrayList();
+        List<Integer> matchingIndex=new ArrayList();
+        List<Object> matchingRecipeMap = new ArrayList();
         int index = 0;
-
-
         // Check across the whole cached recipe map
         // Add each recipe to the matchingRecipes list
         
@@ -172,22 +170,24 @@ public abstract class RecipeUtil {
                     // Add to the back of the list. That way when we cycle through the list
                     // moving items to the front, the index locations for the following items doesn't change
                     matchingRecipeMap.add(recipe);
-                    matchingIndex.add(index);
-                    break;
+                    matchingIndex.add(new Integer(index));
 				}
 			}
             index++;
 		}
-
-        if (matchingIndex.size() > 0 )
+        if (matchingRecipeMap.size() > 0 )
         {
             // Only move the recipes if the last one was beyond 500 in the recipeMap (in GTNH about 57k recipes)
-            if (index > 500) {
-                System.out.println( "Highest recipe found at " + index + ", moving " + matchingIndex.size() + "  to front" );
-                for (index = 0; index < matchingIndex.size(); index++) {
+            if (matchingIndex.get(matchingIndex.size()-1) > 500) {
+            	List recipeMap = CraftingManager.getInstance().getRecipeList();
+                System.out.println( "Highest recipe found at " + matchingIndex.get(matchingIndex.size()-1) + ", moving " + matchingIndex.size() + " to front" );
+                System.out.println("Size of recipe map " + recipeMap.size() );
+                for (index = 0; index < matchingIndex.size(); index++) { // index is reused here, it goes through the matching groups.
                     // Remove recipe and add back at the front
-                    CraftingManager.getInstance().getRecipeList().remove(matchingIndex.get(index));
-                    CraftingManager.getInstance().getRecipeList().add(0,matchingRecipeMap.get(index));
+                    int target = matchingIndex.get(index); // remove requires int
+                    System.out.println("Removing recipe at " + target);
+                    recipeMap.remove(target);
+                    recipeMap.add(0,matchingRecipeMap.get(index));
                 }
             }
         }

--- a/src/main/java/forestry/core/recipes/RecipeUtil.java
+++ b/src/main/java/forestry/core/recipes/RecipeUtil.java
@@ -36,7 +36,7 @@ import forestry.core.utils.Log;
 import forestry.factory.inventory.InventoryCraftingForestry;
 
 public abstract class RecipeUtil {
-
+    static List<Object> cachedRecipes = new ArrayList<Object>();
 	public static void addFermenterRecipes(ItemStack resource, int fermentationValue, Fluids output) {
 		if (RecipeManagers.fermenterManager == null) {
 			return;
@@ -158,7 +158,21 @@ public abstract class RecipeUtil {
         int index = 0;
         // Check across the whole cached recipe map
         // Add each recipe to the matchingRecipes list
-        
+        for (Object recipe : cachedRecipes) {
+			IRecipe irecipe = (IRecipe) recipe;
+
+			if (irecipe.matches(inventory, world)) {
+				ItemStack result = irecipe.getCraftingResult(inventory);
+				if (!ItemStackUtil.containsItemStack(matchingRecipes, result)) {
+					matchingRecipes.add(result);
+				}
+			}
+        }
+        if( matchingRecipes.size() > 0 ) {
+            // If we found recipes here, we found all the potential recipes, so we can just return immediately.
+            return matchingRecipes;
+        }
+
         // Only do this if there were no cached recipes hit
 		for (Object recipe : CraftingManager.getInstance().getRecipeList()) {
 			IRecipe irecipe = (IRecipe) recipe;
@@ -190,6 +204,9 @@ public abstract class RecipeUtil {
                     recipeMap.add(0,matchingRecipeMap.get(index));
                 }
             }
+            // However, we should always add found recipes to the front of the cached recipe map
+            // Location doesn't matter since we have to scan the whole cached recipe map anyways.
+            cachedRecipes.addAll(matchingRecipeMap);
         }
 		return matchingRecipes;
 	}

--- a/src/main/java/forestry/core/recipes/RecipeUtil.java
+++ b/src/main/java/forestry/core/recipes/RecipeUtil.java
@@ -30,6 +30,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 
 import forestry.api.recipes.IDescriptiveRecipe;
 import forestry.api.recipes.RecipeManagers;
+import forestry.core.config.Config;
 import forestry.core.fluids.Fluids;
 import forestry.core.utils.ItemStackUtil;
 import forestry.core.utils.Log;
@@ -156,23 +157,25 @@ public abstract class RecipeUtil {
         List<Integer> matchingIndex=new ArrayList();
         List<Object> matchingRecipeMap = new ArrayList();
         int index = 0;
-        // Check across the whole cached recipe map
-        // Add each recipe to the matchingRecipes list
-        for (Object recipe : cachedRecipes) {
-			IRecipe irecipe = (IRecipe) recipe;
 
-			if (irecipe.matches(inventory, world)) {
-				ItemStack result = irecipe.getCraftingResult(inventory);
-				if (!ItemStackUtil.containsItemStack(matchingRecipes, result)) {
-					matchingRecipes.add(result);
-				}
-			}
-        }
-        if( matchingRecipes.size() > 0 ) {
-            // If we found recipes here, we found all the potential recipes, so we can just return immediately.
-            return matchingRecipes;
-        }
+        if(Config.cacheWorktableRecipes) {
+            // Check across the whole cached recipe map
+            // Add each recipe to the matchingRecipes list
+            for (Object recipe : cachedRecipes) {
+    			IRecipe irecipe = (IRecipe) recipe;
 
+    			if (irecipe.matches(inventory, world)) {
+    				ItemStack result = irecipe.getCraftingResult(inventory);
+    				if (!ItemStackUtil.containsItemStack(matchingRecipes, result)) {
+    					matchingRecipes.add(result);
+    				}
+    			}
+            }
+            if( matchingRecipes.size() > 0 ) {
+                // If we found recipes here, we found all the potential recipes, so we can just return immediately.
+                return matchingRecipes;
+            }
+        }
         // Only do this if there were no cached recipes hit
 		for (Object recipe : CraftingManager.getInstance().getRecipeList()) {
 			IRecipe irecipe = (IRecipe) recipe;
@@ -181,32 +184,38 @@ public abstract class RecipeUtil {
 				ItemStack result = irecipe.getCraftingResult(inventory);
 				if (!ItemStackUtil.containsItemStack(matchingRecipes, result)) {
 					matchingRecipes.add(result);
-                    // Add to the back of the list. That way when we cycle through the list
-                    // moving items to the front, the index locations for the following items doesn't change
-                    matchingRecipeMap.add(recipe);
-                    matchingIndex.add(new Integer(index));
+                    if(Config.promoteWorktableRecipesToFrontOfGlobalRecipemap || Config.cacheWorktableRecipes) {
+                        // Add to the back of the list. That way when we cycle through the list
+                        // moving items to the front, the index locations for the following items doesn't change
+                        matchingRecipeMap.add(recipe);
+                        matchingIndex.add(new Integer(index));
+                    }
 				}
 			}
             index++;
 		}
         if (matchingRecipeMap.size() > 0 )
         {
-            // Only move the recipes if the last one was beyond 500 in the recipeMap (in GTNH about 57k recipes)
-            if (matchingIndex.get(matchingIndex.size()-1) > 500) {
-            	List recipeMap = CraftingManager.getInstance().getRecipeList();
-                System.out.println( "Highest recipe found at " + matchingIndex.get(matchingIndex.size()-1) + ", moving " + matchingIndex.size() + " to front" );
-                System.out.println("Size of recipe map " + recipeMap.size() );
-                for (index = 0; index < matchingIndex.size(); index++) { // index is reused here, it goes through the matching groups.
-                    // Remove recipe and add back at the front
-                    int target = matchingIndex.get(index); // remove requires int
-                    System.out.println("Removing recipe at " + target);
-                    recipeMap.remove(target);
-                    recipeMap.add(0,matchingRecipeMap.get(index));
+            if (Config.promoteWorktableRecipesToFrontOfGlobalRecipemap) {
+                // Only move the recipes if the last one was beyond 500 in the recipeMap (in GTNH about 57k recipes)
+                if (matchingIndex.get(matchingIndex.size()-1) > 500) {
+                    List recipeMap = CraftingManager.getInstance().getRecipeList();
+                    System.out.println( "Highest recipe found at " + matchingIndex.get(matchingIndex.size()-1) + ", moving " + matchingIndex.size() + " to front" );
+                    System.out.println( "Size of recipe map " + recipeMap.size() );
+                    for (index = 0; index < matchingIndex.size(); index++) { // index is reused here, it goes through the matching groups.
+                        // Remove recipe and add back at the front
+                        int target = matchingIndex.get(index); // remove requires int
+                        System.out.println("Removing recipe at " + target);
+                        recipeMap.remove(target);
+                        recipeMap.add(0,matchingRecipeMap.get(index));
+                    }
                 }
             }
-            // However, we should always add found recipes to the front of the cached recipe map
-            // Location doesn't matter since we have to scan the whole cached recipe map anyways.
-            cachedRecipes.addAll(matchingRecipeMap);
+            if(Config.cacheWorktableRecipes) {
+                // However, we should always add found recipes the cached recipe map
+                // Location doesn't matter since we have to scan the whole cached recipe map anyways.
+                cachedRecipes.addAll(matchingRecipeMap);
+            }
         }
 		return matchingRecipes;
 	}

--- a/src/main/java/forestry/core/recipes/RecipeUtil.java
+++ b/src/main/java/forestry/core/recipes/RecipeUtil.java
@@ -99,7 +99,6 @@ public abstract class RecipeUtil {
 		if (ItemStackUtil.containsSets(recipeItems, availableItems, true, true) == 0) {
 			return null;
 		}
-
 		// Check that it doesn't make a different recipe.
 		// For example:
 		// Wood Logs are all ore dictionary equivalent with each other,
@@ -140,7 +139,6 @@ public abstract class RecipeUtil {
 				}
 			}
 		}
-
 		List<ItemStack> outputs = findMatchingRecipes(crafting, world);
 		if (!ItemStackUtil.containsItemStack(outputs, recipeOutput)) {
 			return null;
@@ -155,7 +153,15 @@ public abstract class RecipeUtil {
 		}
 
 		List<ItemStack> matchingRecipes = new ArrayList<>();
+        List<int> matchingIndex=new ArrayList();
+        List matchingRecipeMap = new ArrayList();
+        int index = 0;
 
+
+        // Check across the whole cached recipe map
+        // Add each recipe to the matchingRecipes list
+        
+        // Only do this if there were no cached recipes hit
 		for (Object recipe : CraftingManager.getInstance().getRecipeList()) {
 			IRecipe irecipe = (IRecipe) recipe;
 
@@ -163,10 +169,28 @@ public abstract class RecipeUtil {
 				ItemStack result = irecipe.getCraftingResult(inventory);
 				if (!ItemStackUtil.containsItemStack(matchingRecipes, result)) {
 					matchingRecipes.add(result);
+                    // Add to the back of the list. That way when we cycle through the list
+                    // moving items to the front, the index locations for the following items doesn't change
+                    matchingRecipeMap.add(recipe);
+                    matchingIndex.add(index);
+                    break;
 				}
 			}
+            index++;
 		}
 
+        if (matchingIndex.size() > 0 )
+        {
+            // Only move the recipes if the last one was beyond 500 in the recipeMap (in GTNH about 57k recipes)
+            if (index > 500) {
+                System.out.println( "Highest recipe found at " + index + ", moving " + matchingIndex.size() + "  to front" );
+                for (index = 0; index < matchingIndex.size(); index++) {
+                    // Remove recipe and add back at the front
+                    CraftingManager.getInstance().getRecipeList().remove(matchingIndex.get(index));
+                    CraftingManager.getInstance().getRecipeList().add(0,matchingRecipeMap.get(index));
+                }
+            }
+        }
 		return matchingRecipes;
 	}
 

--- a/src/main/java/forestry/core/utils/SlotUtil.java
+++ b/src/main/java/forestry/core/utils/SlotUtil.java
@@ -265,6 +265,7 @@ public abstract class SlotUtil {
 	// if mergeOnly = true, don't shift into empty slots.
 	private static boolean shiftToMachineInventory(List inventorySlots, ItemStack stackToShift, int numSlots, boolean mergeOnly) {
 		for (int machineIndex = playerInventorySize; machineIndex < numSlots; machineIndex++) {
+//            System.out.println("SlotUtil::shiftToMachineinventory");
 			Slot slot = (Slot) inventorySlots.get(machineIndex);
 			if (mergeOnly && slot.getStack() == null) {
 				continue;

--- a/src/main/java/forestry/factory/tiles/TileWorktable.java
+++ b/src/main/java/forestry/factory/tiles/TileWorktable.java
@@ -44,6 +44,8 @@ public class TileWorktable extends TileBase implements ICrafterWorktable {
     private long savedTick = 0;
     private long savedSystemTimeExpiration = 0;
     private boolean isDirty=true;
+    private long cleanCount = 0;
+    private long totalCount = 0;
     
     // Maximum crafting time of 750ms before ejecting out and stop hard-locking the server
     static long WORKTABLE_MAX_CRAFT_TIME = 750 * 1000 * 1000;
@@ -141,15 +143,25 @@ public class TileWorktable extends TileBase implements ICrafterWorktable {
             savedTick=currentTick;
             savedSystemTimeExpiration = System.nanoTime() + WORKTABLE_MAX_CRAFT_TIME;
             isDirty = true;
+            System.out.println("cleanCount " + cleanCount + " totalCount " + totalCount);
+            cleanCount = 0;
+            totalCount = 0;
         }
 
-		ItemStack[] recipeItems = InventoryUtil.getStacks(currentRecipe.getCraftMatrix());
-		ItemStack[] inventory = InventoryUtil.getStacks(this);
-		InventoryCraftingForestry crafting = RecipeUtil.getCraftRecipe(recipeItems, inventory, worldObj, currentRecipe.getRecipeOutput());
+        totalCount++;
+        
+        if (isDirty) {
+    		ItemStack[] recipeItems = InventoryUtil.getStacks(currentRecipe.getCraftMatrix());
+    		ItemStack[] inventory = InventoryUtil.getStacks(this);
+    		InventoryCraftingForestry crafting = RecipeUtil.getCraftRecipe(recipeItems, inventory, worldObj, currentRecipe.getRecipeOutput());
 
-        // Craft is validated, mark as clean
-        isDirty = false;
-		return crafting != null;
+            // Craft is validated, mark as clean
+            isDirty = false;
+            return crafting != null;
+        } else {
+            cleanCount++;
+            return true;
+        }
 	}
 
 	@Override
@@ -172,7 +184,9 @@ public class TileWorktable extends TileBase implements ICrafterWorktable {
 		if (removed == null) {
 			return false;
 		}
-
+        
+        // Contents have changed, have to revalidate recipe
+        isDirty = true;
 		// update crafting display to match the ingredients that were actually used
 		setCraftingDisplay(crafting);
 		return true;


### PR DESCRIPTION
Fixes shift-lag for Forestry worktable.
Supports options for

halting crafting after so many ms
creating a local cache of recipes
updating the global recipe map to move recipes to the front that are used, making them faster for everyone.

This may cause problems with recipes that are wildcarded, it is still under evaluation.

Lang files are under a separate repo, so no detailed info in the config file. Should be easy to figure out.