### PR TITLE
Dirty fix for BQ3 crafting quest not triggering

### DIFF
--- a/src/main/java/forestry/core/gui/ContainerForestry.java
+++ b/src/main/java/forestry/core/gui/ContainerForestry.java
@@ -83,7 +83,7 @@ public abstract class ContainerForestry extends Container {
 	}
 
 	@Override
-	public final ItemStack transferStackInSlot(EntityPlayer player, int slotIndex) {
+	public ItemStack transferStackInSlot(EntityPlayer player, int slotIndex) {
 		if (!canAccess(player)) {
 			return null;
 		}


### PR DESCRIPTION
While this can also be done on BQ3 side, the necessary info, i.e. stack size, would be lost (without injection of new ASM call hooks of course). On BQ3 side it would have to go through the crafting recipes again to find the stack size, which can be quite a slow process. Since batch crafting using worktable can already be cause some serious lag, there is no reason to do it there if we have control over both code base.