### PR TITLE
Fix NPE on crafting in worktable

### DIFF
--- a/src/main/java/forestry/core/gui/slots/SlotCrafter.java
+++ b/src/main/java/forestry/core/gui/slots/SlotCrafter.java
@@ -56,7 +56,7 @@ public class SlotCrafter extends SlotCrafting {
 
 	@Override
 	public void onPickupFromSlot(EntityPlayer player, ItemStack itemStack) {
-		if (!crafter.onCraftingStart(player)) {
+		if (itemStack == null || !crafter.onCraftingStart(player)) {
 			return;
 		}
 


### PR DESCRIPTION
Not sure why this happens. It appears under some extreme cases minecraft GUI system will pass in a null itemstack

GTNewHorizons/GT-New-Horizons-Modpack#7414