### PR TITLE
Pams' Harvest The Nether Compatibility

### DIFF
--- a/src/main/java/forestry/plugins/compat/PluginHarvestCraft.java
+++ b/src/main/java/forestry/plugins/compat/PluginHarvestCraft.java
@@ -380,6 +380,7 @@ public class PluginHarvestCraft extends ForestryPlugin {
 			RecipeUtil.addRecipe(ForestryAPI.activeMode.getStackSetting("recipe.output.capsule"), "XXX ", 'X', hcBeeswaxItem);
 		}
 
+		// Recipe registering for Pam's Harvest the Nether
 		if (ModUtil.isModLoaded(HCN)) {
 			for (String netherCropName : genericNetherCrops) {
 				ItemStack genericNetherCropSeed = GameRegistry.findItemStack(HCN, netherCropName + "seedItem", 1);
@@ -387,9 +388,18 @@ public class PluginHarvestCraft extends ForestryPlugin {
 				if (genericNetherCropSeed != null) {
 					RecipeManagers.squeezerManager.addRecipe(10, new ItemStack[]{genericNetherCropSeed}, Fluids.SEEDOIL.getFluid(seedamount));
 				}
+
 				if (PluginManager.Module.FARMING.isEnabled() && genericNetherCropSeed != null && genericNetherCropBlock != null) {
-					Farmables.farmables.get(FarmableReference.Wheat.get()).add(new FarmableGenericCrop(genericNetherCropSeed, genericNetherCropBlock, 7));
+					// Add all crops to orchard farms
 					Farmables.farmables.get(FarmableReference.Orchard.get()).add(new FarmableBasicFruit(genericNetherCropBlock, 7));
+					
+					if (netherCropName == "glowflower") {
+						// Add glowflowers to managed and manual crop farms
+						Farmables.farmables.get(FarmableReference.Wheat.get()).add(new FarmableGenericCrop(genericNetherCropSeed, genericNetherCropBlock, 7));
+					} else {
+						// Add every other crop to infernal farms, since they only grow on soul sand
+						Farmables.farmables.get(FarmableReference.Infernal.get()).add(new FarmableGenericCrop(genericNetherCropSeed, genericNetherCropBlock, 7));
+					}
 				}
 			}
 		}

--- a/src/main/java/forestry/plugins/compat/PluginHarvestCraft.java
+++ b/src/main/java/forestry/plugins/compat/PluginHarvestCraft.java
@@ -39,6 +39,7 @@ import forestry.plugins.PluginManager;
 public class PluginHarvestCraft extends ForestryPlugin {
 
 	private static final String HC = "harvestcraft";
+	private static final String HCN = "harvestthenether";
 
 	@Override
 	public boolean isAvailable() {
@@ -190,6 +191,17 @@ public class PluginHarvestCraft extends ForestryPlugin {
 
 		ImmutableList<String> genericCrops = genericCropsBuilder.build();
 
+		// Pam's Harvest The Nether Crops
+		ImmutableList.Builder<String> genericNetherCropsBuilder = ImmutableList.builder();
+		genericNetherCropsBuilder.add(
+				"glowflower",
+				"fleshroot",
+				"bloodleaf",
+				"marrowberry"
+		);
+		
+		ImmutableList<String> genericNetherCrops = genericNetherCropsBuilder.build();
+
 		ImmutableList.Builder<String> plants = ImmutableList.builder();
 
 		int juiceAmount = ForestryAPI.activeMode.getIntegerSetting("squeezer.liquid.apple") / 25;
@@ -309,6 +321,7 @@ public class PluginHarvestCraft extends ForestryPlugin {
 			}
 			plants.add(cropName);
 		}
+
 		ItemStack mustardCropSeed = GameRegistry.findItemStack(HC, "mustard" + "seedItem", 1);
 		Block mustardCropBlock = GameRegistry.findBlock(HC, "pam" + "mustardseeds" + "Crop");
 		ItemStack mustardFruit = GameRegistry.findItemStack(HC, "mustard" + "seedsItem", 1);
@@ -365,6 +378,20 @@ public class PluginHarvestCraft extends ForestryPlugin {
 		ItemStack hcBeeswaxItem = GameRegistry.findItemStack(HC, "beeswaxItem", 1);
 		if (hcBeeswaxItem != null) {
 			RecipeUtil.addRecipe(ForestryAPI.activeMode.getStackSetting("recipe.output.capsule"), "XXX ", 'X', hcBeeswaxItem);
+		}
+
+		if (ModUtil.isModLoaded(HCN)) {
+			for (String netherCropName : genericNetherCrops) {
+				ItemStack genericNetherCropSeed = GameRegistry.findItemStack(HCN, netherCropName + "seedItem", 1);
+				Block genericNetherCropBlock = GameRegistry.findBlock(HCN, netherCropName + "Crop");
+				if (genericNetherCropSeed != null) {
+					RecipeManagers.squeezerManager.addRecipe(10, new ItemStack[]{genericNetherCropSeed}, Fluids.SEEDOIL.getFluid(seedamount));
+				}
+				if (PluginManager.Module.FARMING.isEnabled() && genericNetherCropSeed != null && genericNetherCropBlock != null) {
+					Farmables.farmables.get(FarmableReference.Wheat.get()).add(new FarmableGenericCrop(genericNetherCropSeed, genericNetherCropBlock, 7));
+					Farmables.farmables.get(FarmableReference.Orchard.get()).add(new FarmableBasicFruit(genericNetherCropBlock, 7));
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
With this MultiFarms should be able to harvest all the crops from Pam's Harvest the Nether:
| Crop | Soil | Farmtype |
| ------------- | ------------- |------------- |
| Glow Flower | Farmland | Crop Farm & Orchard  |
| Flesh Root | Soul Sand | Infernal Farm & Orchard  |
| Marrow Berry | Soul Sand | Infernal Farm & Orchard  |
| Blood Leaf | Soul Sand | Infernal Farm & Orchard  |

This pull request also adds the following items as squeezer recipes (Each seed will produce 3mB of  Seedoil in the squeezer):
- Glow Flower Seed
- Marrow Berry Seed
- Blood Leaf Seed
- Flesh Root Seed

It is still up for debate, whether Flesh Root, Marrow Berry and Blood Leaf should be harvestable in orchard mode or not, since Nether Warts are only harvestable with infernal farms. 
However, I think it is covenient to include the change this change for pams crops to have a manual alternative for infernal farms.

For reference, some already closed issues mentioned the missing support of Pam's Harvest the Nether with MultiFarms:
- GTNewHorizons/GT-New-Horizons-Modpack#7759
- GTNewHorizons/GT-New-Horizons-Modpack#7588