### PR TITLE
Cofh dep

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile('com.github.GTNewHorizons:BuildCraft:7.1.27:api')
     compile('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
 
-    compile('curse.maven:cofh-core-69162:2388751')
+    compile('curse.maven:cofh-lib-220333:2388748')
 
     compileOnly('curse.maven:craftguide-75557:2459320')
 }

--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -61,7 +61,6 @@ import forestry.plugins.PluginManager;
 		version = Constants.VERSION,
 		guiFactory = "forestry.core.config.ForestryGuiConfigFactory",
 		dependencies = "required-after:Forge@[10.13.4.1566,);"
-				+ "required-after:CoFHCore;"
 				+ "after:Buildcraft|Core@[6.1.7,);"
 				+ "after:ExtrabiomesXL;"
 				+ "after:BiomesOPlenty;"

--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -85,7 +85,7 @@ public class Forestry {
 
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
-        checkForCoFHLib();
+		checkForCoFHLib();
 		packetHandler = new PacketHandler();
 
 		// Register event handler
@@ -161,8 +161,8 @@ public class Forestry {
 	}
 	
 	private static void checkForCoFHLib() {
-	    if (!ModAPIManager.INSTANCE.hasAPI("CoFHAPI|energy")) {
-	        throw new RuntimeException("CoFHAPI|energy could not be found! This version of Forestry does not contain the RedstoneFlux API anymore, so you have to install either CoFHLib or CoFHCore.");
-	    }
+		if (!ModAPIManager.INSTANCE.hasAPI("CoFHAPI|energy")) {
+			throw new RuntimeException("CoFHAPI|energy could not be found! This version of Forestry does not contain the RedstoneFlux API anymore, so you have to install either CoFHLib or CoFHCore.");
+		}
 	}
 }

--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -20,6 +20,7 @@ import net.minecraftforge.common.MinecraftForge;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.ModAPIManager;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.event.FMLInterModComms.IMCEvent;
@@ -38,7 +39,6 @@ import forestry.core.EventHandlerCore;
 import forestry.core.config.Config;
 import forestry.core.config.Constants;
 import forestry.core.config.GameMode;
-import forestry.core.config.Version;
 import forestry.core.errors.EnumErrorCode;
 import forestry.core.errors.ErrorStateRegistry;
 import forestry.core.gui.GuiHandler;
@@ -85,6 +85,7 @@ public class Forestry {
 
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
+        checkForCoFHLib();
 		packetHandler = new PacketHandler();
 
 		// Register event handler
@@ -157,5 +158,11 @@ public class Forestry {
 				}
 			}
 		}
+	}
+	
+	private static void checkForCoFHLib() {
+	    if (!ModAPIManager.INSTANCE.hasAPI("CoFHAPI|energy")) {
+	        throw new RuntimeException("CoFHAPI|energy could not be found! This version of Forestry does not contain the RedstoneFlux API anymore, so you have to install either CoFHLib or CoFHCore.");
+	    }
 	}
 }


### PR DESCRIPTION
In https://github.com/GTNewHorizons/ForestryMC/pull/23 I said that surely implementing `@Optional.Interface` would solve the problem of Forestry crashing because it can't find some `cofh.api.**` classes. After poking at it for a while, I noticed that this won't be possible because the RedstoneFlux API is just too deep implemented in Forestry. In the official versions this wasn't a problem, as they simply [shaded all CoFH API classes into the jar](https://github.com/ForestryMC/ForestryMC/blob/mc-1.7.10/build.gradle#L154-L156).
In my opinion neither including all CoFH API classes, nor having a hard-dep on CoFHCore is a nice solution, so I added a check to see if `CoFHAPI|energy` is present. It doesn't matter if the classes are in CoFHCore, CoFHLib or shaded by any other mod as long as FML knows that the API is present. If it isn't, the game will crash with this exception:
```log
java.lang.RuntimeException: CoFHAPI|energy could not be found! This version of Forestry does not contain the RedstoneFlux API anymore, so you have to install either CoFHLib or CoFHCore.
	at forestry.Forestry.checkForCoFHLib(Forestry.java:165)
	at forestry.Forestry.preInit(Forestry.java:88)
...
```
Like before, either CoFHLib or CoFHCore still has to be added to every project which uses Forestry at runtime (this wasn't changed with #23 either).