### PR TITLE
Fixed Secondary Species Primary Production

### DIFF
--- a/src/main/java/forestry/apiculture/genetics/Bee.java
+++ b/src/main/java/forestry/apiculture/genetics/Bee.java
@@ -524,7 +524,7 @@ public class Bee extends IndividualLiving implements IBee {
         // / Secondary Products
         for (Map.Entry<ItemStack, Float> entry : secondary.getProductChances().entrySet()) {
             if (housing.getWorld().rand.nextFloat()
-                    < getFinalChance(Math.round(entry.getValue() / 2), speed, prodModifier, 1f)) {
+                    < getFinalChance(entry.getValue() / 2, speed, prodModifier, 1f)) {
                 products.add(entry.getKey().copy());
             }
         }


### PR DESCRIPTION
What bug is being fixed?

Calling Math.round on probabilities is a logical error.  This bug exists in base forestry.  My best guess is that `entry.getValue()` was stored as a percentage at some point.  When applied to a probability `c`, `Math.round(c/2)` will just be equivalent to `c >= 1.0 ? 1.0 : 0.0`, which probably wasn't intended.  See "tips-and-tricks/secret bees the questbook doesn't want you to know about" on the discord for more info on how I noticed this bug.

How does this affect bee production?

For purebred bees with a housing production modifier of 16x and a speed of blinding (2.0), this is between a 1.5x multiplier (when base production chance is 27%) and a 2x multiplier (when base production chance is at least 56%).  If the base chance is 100% though, the behavior is unchanged.

@Runakai1 