### PR TITLE
Auto-apply stats tooltips to all IHiveFrame items

### DIFF
--- a/src/main/java/forestry/api/apiculture/IHiveFrame.java
+++ b/src/main/java/forestry/api/apiculture/IHiveFrame.java
@@ -5,6 +5,10 @@
  ******************************************************************************/
 package forestry.api.apiculture;
 
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import net.minecraft.item.ItemStack;
 
 public interface IHiveFrame {
@@ -22,4 +26,14 @@ public interface IHiveFrame {
     ItemStack frameUsed(IBeeHousing housing, ItemStack frame, IBee queen, int wear);
 
     IBeeModifier getBeeModifier();
+
+    /**
+     * Provides an override for the "Hold Shift" tooltip info for a frame.
+     *
+     * @return The info to display for this frame, or null if default generated info.
+     */
+    @Nullable
+    default List<String> getFrameTooltip() {
+        return null;
+    }
 }

--- a/src/main/java/forestry/api/apiculture/IHiveFrame.java
+++ b/src/main/java/forestry/api/apiculture/IHiveFrame.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 
 public interface IHiveFrame {
 
@@ -28,7 +29,8 @@ public interface IHiveFrame {
     IBeeModifier getBeeModifier();
 
     /**
-     * Provides an override for the "Hold Shift" tooltip info for a frame.
+     * Provides an override for the "Hold Shift" tooltip info for a frame.<br>
+     * Called by {@link forestry.apiculture.EventHandlerApiculture#addFrameTooltip(ItemTooltipEvent)}.
      *
      * @return The info to display for this frame, or null if default generated info.
      */

--- a/src/main/java/forestry/apiculture/EventHandlerApiculture.java
+++ b/src/main/java/forestry/apiculture/EventHandlerApiculture.java
@@ -43,7 +43,7 @@ public class EventHandlerApiculture {
                     tooltip.add(StringUtil.localize("frame.tooltip.lifespan") + getColorFormatted(lifespan));
 
                     float production = modifier.getProductionModifier(null, 1.0F);
-                    tooltip.add(StringUtil.localize("frame.tooltip.production") + getColorFormatted(production));
+                    tooltip.add(StringUtil.localize("frame.tooltip.production") + getColorFormatted(production, true));
 
                     float decay = modifier.getGeneticDecay(null, 1.0F);
                     tooltip.add(StringUtil.localize("frame.tooltip.geneticDecay") + getColorFormatted(decay));
@@ -68,7 +68,7 @@ public class EventHandlerApiculture {
         return color + " " + durability;
     }
 
-    private static String getColorFormatted(float value) {
+    private static String getColorFormatted(float value, boolean additive) {
         EnumChatFormatting color;
         if (value <= 0.5F) {
             color = EnumChatFormatting.DARK_RED; // "bad" stat
@@ -81,11 +81,23 @@ public class EventHandlerApiculture {
         } else {
             color = EnumChatFormatting.AQUA; // "great" stat
         }
+        String formatted = color.toString();
+
+        // Set symbol for if this value is additive or multiplicative
+        if (additive) {
+            formatted += " +";
+        } else {
+            formatted += " x";
+        }
 
         // trim trailing zeroes if no decimal-precision is needed
         if (value == (long) value) {
-            return color + " x" + (long) value;
+            return formatted + (long) value;
         }
-        return color + " x" + value;
+        return formatted + value;
+    }
+
+    private static String getColorFormatted(float value) {
+        return getColorFormatted(value, false);
     }
 }

--- a/src/main/java/forestry/apiculture/EventHandlerApiculture.java
+++ b/src/main/java/forestry/apiculture/EventHandlerApiculture.java
@@ -25,23 +25,29 @@ public class EventHandlerApiculture {
             if (!Proxies.common.isShiftDown()) {
                 tooltip.add(EnumChatFormatting.ITALIC + "<" + StringUtil.localize("gui.tooltip.tmi") + ">");
             } else {
-                int durability = itemStack.getMaxDamage();
-                tooltip.add(StringUtil.localize("frame.tooltip.durability") + getDurabilityFormatted(durability));
+                if (frame.getFrameTooltip() != null) {
+                    // use the override if it exists
+                    tooltip.addAll(frame.getFrameTooltip());
+                } else {
+                    // otherwise use the auto-generated info
+                    int durability = itemStack.getMaxDamage();
+                    tooltip.add(StringUtil.localize("frame.tooltip.durability") + getDurabilityFormatted(durability));
 
-                float territory = modifier.getTerritoryModifier(null, 1.0F);
-                tooltip.add(StringUtil.localize("frame.tooltip.territory") + getColorFormatted(territory));
+                    float territory = modifier.getTerritoryModifier(null, 1.0F);
+                    tooltip.add(StringUtil.localize("frame.tooltip.territory") + getColorFormatted(territory));
 
-                float mutation = modifier.getMutationModifier(null, null, 1.0F);
-                tooltip.add(StringUtil.localize("frame.tooltip.mutationRate") + getColorFormatted(mutation));
+                    float mutation = modifier.getMutationModifier(null, null, 1.0F);
+                    tooltip.add(StringUtil.localize("frame.tooltip.mutationRate") + getColorFormatted(mutation));
 
-                float lifespan = modifier.getLifespanModifier(null, null, 1.0F);
-                tooltip.add(StringUtil.localize("frame.tooltip.lifespan") + getColorFormatted(lifespan));
+                    float lifespan = modifier.getLifespanModifier(null, null, 1.0F);
+                    tooltip.add(StringUtil.localize("frame.tooltip.lifespan") + getColorFormatted(lifespan));
 
-                float production = modifier.getProductionModifier(null, 1.0F);
-                tooltip.add(StringUtil.localize("frame.tooltip.production") + getColorFormatted(production));
+                    float production = modifier.getProductionModifier(null, 1.0F);
+                    tooltip.add(StringUtil.localize("frame.tooltip.production") + getColorFormatted(production));
 
-                float decay = modifier.getGeneticDecay(null, 1.0F);
-                tooltip.add(StringUtil.localize("frame.tooltip.geneticDecay") + getColorFormatted(decay));
+                    float decay = modifier.getGeneticDecay(null, 1.0F);
+                    tooltip.add(StringUtil.localize("frame.tooltip.geneticDecay") + getColorFormatted(decay));
+                }
             }
         }
     }

--- a/src/main/java/forestry/apiculture/EventHandlerApiculture.java
+++ b/src/main/java/forestry/apiculture/EventHandlerApiculture.java
@@ -1,0 +1,85 @@
+package forestry.apiculture;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import forestry.api.apiculture.IBeeModifier;
+import forestry.api.apiculture.IHiveFrame;
+import forestry.core.proxy.Proxies;
+import forestry.core.utils.StringUtil;
+
+public class EventHandlerApiculture {
+
+    @SubscribeEvent
+    public void addFrameTooltip(ItemTooltipEvent event) {
+        ItemStack itemStack = event.itemStack;
+        if (itemStack != null && itemStack.getItem() instanceof IHiveFrame) {
+            IHiveFrame frame = (IHiveFrame) itemStack.getItem();
+            IBeeModifier modifier = frame.getBeeModifier();
+            List<String> tooltip = event.toolTip;
+
+            if (!Proxies.common.isShiftDown()) {
+                tooltip.add(EnumChatFormatting.ITALIC + "<" + StringUtil.localize("gui.tooltip.tmi") + ">");
+            } else {
+                int durability = itemStack.getMaxDamage();
+                tooltip.add(StringUtil.localize("frame.tooltip.durability") + getDurabilityFormatted(durability));
+
+                float territory = modifier.getTerritoryModifier(null, 1.0F);
+                tooltip.add(StringUtil.localize("frame.tooltip.territory") + getColorFormatted(territory));
+
+                float mutation = modifier.getMutationModifier(null, null, 1.0F);
+                tooltip.add(StringUtil.localize("frame.tooltip.mutationRate") + getColorFormatted(mutation));
+
+                float lifespan = modifier.getLifespanModifier(null, null, 1.0F);
+                tooltip.add(StringUtil.localize("frame.tooltip.lifespan") + getColorFormatted(lifespan));
+
+                float production = modifier.getProductionModifier(null, 1.0F);
+                tooltip.add(StringUtil.localize("frame.tooltip.production") + getColorFormatted(production));
+
+                float decay = modifier.getGeneticDecay(null, 1.0F);
+                tooltip.add(StringUtil.localize("frame.tooltip.geneticDecay") + getColorFormatted(decay));
+            }
+        }
+    }
+
+    private static String getDurabilityFormatted(int durability) {
+        EnumChatFormatting color;
+        if (durability < 100) {
+            color = EnumChatFormatting.DARK_RED;
+        } else if (durability < 200) {
+            color = EnumChatFormatting.RED;
+        } else if (durability < 250) {
+            color = EnumChatFormatting.GOLD;
+        } else if (durability < 750) {
+            color = EnumChatFormatting.GREEN;
+        } else {
+            color = EnumChatFormatting.AQUA;
+        }
+        return color + " " + durability;
+    }
+
+    private static String getColorFormatted(float value) {
+        EnumChatFormatting color;
+        if (value <= 0.5F) {
+            color = EnumChatFormatting.DARK_RED; // "bad" stat
+        } else if (value < 1.0F) {
+            color = EnumChatFormatting.RED; // "below average" stat
+        } else if (value == 1.0F) {
+            color = EnumChatFormatting.GOLD; // "average" stat
+        } else if (value <= 2.0F) {
+            color = EnumChatFormatting.GREEN; // "above average" stat
+        } else {
+            color = EnumChatFormatting.AQUA; // "great" stat
+        }
+
+        // trim trailing zeroes if no decimal-precision is needed
+        if (value == (long) value) {
+            return color + " x" + (long) value;
+        }
+        return color + " x" + value;
+    }
+}

--- a/src/main/java/forestry/plugins/PluginApiculture.java
+++ b/src/main/java/forestry/plugins/PluginApiculture.java
@@ -60,6 +60,7 @@ import forestry.api.recipes.RecipeManagers;
 import forestry.api.storage.ICrateRegistry;
 import forestry.api.storage.StorageManager;
 import forestry.apiculture.ArmorApiaristHelper;
+import forestry.apiculture.EventHandlerApiculture;
 import forestry.apiculture.SaveEventHandlerApiculture;
 import forestry.apiculture.VillageHandlerApiculture;
 import forestry.apiculture.blocks.BlockAlveary;
@@ -185,6 +186,7 @@ public class PluginApiculture extends ForestryPlugin {
         super.preInit();
 
         MinecraftForge.EVENT_BUS.register(this);
+        MinecraftForge.EVENT_BUS.register(new EventHandlerApiculture());
 
         blocks.apiculture.addDefinitions(
                 new MachineDefinition(BlockApicultureType.APIARY).setFaces(0, 1, 2, 2, 4, 4, 0, 7),

--- a/src/main/resources/assets/forestry/lang/en_US.lang
+++ b/src/main/resources/assets/forestry/lang/en_US.lang
@@ -568,6 +568,13 @@ item.for.frameImpregnated.name=Impregnated Frame
 item.for.frameProven.name=Proven Frame
 item.for.frameUntreated.name=Untreated Frame
 
+for.frame.tooltip.durability=Durability:
+for.frame.tooltip.territory=Territory:
+for.frame.tooltip.mutationRate=Mutation Rate:
+for.frame.tooltip.lifespan=Lifespan:
+for.frame.tooltip.production=Production:
+for.frame.tooltip.geneticDecay=Genetic Decay:
+
 item.for.fruits.cherry.name=Cherry
 item.for.fruits.chestnut.name=Chestnut
 item.for.fruits.dates.name=Date


### PR DESCRIPTION
Adds the `Hold Shift` style tooltip to all `IHiveFrame` items. This means that all Forestry frames, as well as any provided by addons, will be automatically applied.

Discrepancies from current tooltips:
- Colors have been changed to be consistent, following a scheme of:
    - DARK_RED: very low stat
    - RED: below average stat
    - GOLD: average stat (usually just `x1`
    - GREEN: above average stat
    - AQUA: very good stat
- A handful of minor inconsistencies in the old tooltips beyond colors are addressed
- The tooltip stating "Hold Shift" is slightly modified to use Forestry's existing lang key
- Very low stats (like the Lifespan stat of the Mutagenic Frame) are displayed in scientific notation now, as that is how Java formats small double/float values to String

Supersedes #37  