### PR TITLE
Fix a bug when NBTString does not exist.

### DIFF
--- a/src/main/java/forestry/core/inventory/ItemInventory.java
+++ b/src/main/java/forestry/core/inventory/ItemInventory.java
@@ -106,7 +106,7 @@ public abstract class ItemInventory implements IInventory, IFilterSlotDelegate {
 
         String baseUID = base.getTagCompound().getString(KEY_UID);
         String comparisonUID = comparison.getTagCompound().getString(KEY_UID);
-        return baseUID != null && comparisonUID != null && baseUID.equals(comparisonUID);
+        return baseUID != null && !baseUID.isEmpty() && baseUID.equals(comparisonUID);
     }
 
     public void readFromNBT(NBTTagCompound nbt) {


### PR DESCRIPTION
This bug causes items with inventory to be flushed under certain conditions. This is an old, legacy bug. NBTString returns an empty string if it doesn't exist.