### PR TITLE
Allocation reduction

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,9 +2,9 @@
 
 dependencies {
     api('curse.maven:cofh-lib-220333:2388748')
-    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.3-GTNH:dev')
-    compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.6.1:api')
-    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.38:api')
+    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.18-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.6.2:api')
+    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.39:api')
     compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
     compileOnly('curse.maven:craftguide-75557:2459320')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
 }
 
 

--- a/src/main/java/forestry/apiculture/BeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/BeekeepingLogic.java
@@ -115,7 +115,7 @@ public class BeekeepingLogic implements IBeekeepingLogic, IStreamable {
 
         Stack<ItemStack> spawnCopy = new Stack<>();
         if (spawn.size() < 128) spawnCopy.addAll(spawn);
-        else for (byte b = 0; b < 128; ++b) spawnCopy.add(spawn.get(b));
+        else for (int b = 0; b < 128; ++b) spawnCopy.add(spawn.get(b));
         NBTTagList nbttaglist = new NBTTagList();
         while (!spawnCopy.isEmpty() && spawnCopy.size() <= 128) {
             NBTTagCompound nbttagcompound1 = new NBTTagCompound();

--- a/src/main/java/forestry/apiculture/multiblock/TileAlvearySwarmer.java
+++ b/src/main/java/forestry/apiculture/multiblock/TileAlvearySwarmer.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.apiculture.multiblock;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Map.Entry;
-import java.util.Stack;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ISidedInventory;
@@ -39,7 +40,7 @@ import forestry.core.utils.ItemStackUtil;
 public class TileAlvearySwarmer extends TileAlveary implements ISidedInventory, IActivatable, IAlvearyComponent.Active {
 
     private final InventorySwarmer inventory;
-    private final Stack<ItemStack> pendingSpawns = new Stack<>();
+    private final Deque<ItemStack> pendingSpawns = new ArrayDeque<>();
     private boolean active;
 
     public TileAlvearySwarmer() {

--- a/src/main/java/forestry/core/gui/GuiAlyzer.java
+++ b/src/main/java/forestry/core/gui/GuiAlyzer.java
@@ -8,10 +8,11 @@
  ******************************************************************************/
 package forestry.core.gui;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Stack;
 
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -208,7 +209,7 @@ public abstract class GuiAlyzer extends GuiForestry<ContainerAlyzer, IInventory>
         textLayout.drawLine(StringUtil.localize("gui.alyzer.classification") + ":", 12);
         textLayout.newLine();
 
-        Stack<IClassification> hierarchy = new Stack<>();
+        Deque<IClassification> hierarchy = new ArrayDeque<>();
         IClassification classification = individual.getGenome().getPrimary().getBranch();
         while (classification != null) {
 

--- a/src/main/java/forestry/core/utils/vect/IVect.java
+++ b/src/main/java/forestry/core/utils/vect/IVect.java
@@ -44,6 +44,10 @@ public interface IVect extends Comparable<IVect> {
 
     MutableVect asMutable();
 
+    // NOTE: All classes implementing this must implement the same hashCode and equals methods as Vect
+    int hashCode();
+    boolean equals(Object obj);
+
     default int compareTo(IVect other) {
         int x = this.getX() - other.getX();
         if (x != 0) {

--- a/src/main/java/forestry/core/utils/vect/IVect.java
+++ b/src/main/java/forestry/core/utils/vect/IVect.java
@@ -34,5 +34,13 @@ public interface IVect {
 
     IVect add(ChunkCoordinates coordinates);
 
+    IVect multiply(int factor);
+
+    IVect multiply(float factor);
+
     int[] toArray();
+
+    Vect asImmutable();
+
+    MutableVect asMutable();
 }

--- a/src/main/java/forestry/core/utils/vect/IVect.java
+++ b/src/main/java/forestry/core/utils/vect/IVect.java
@@ -16,7 +16,7 @@ import forestry.api.farming.FarmDirection;
 /**
  * Represents a position or dimensions.
  */
-public interface IVect {
+public interface IVect extends Comparable<IVect> {
 
     int getX();
 
@@ -43,4 +43,18 @@ public interface IVect {
     Vect asImmutable();
 
     MutableVect asMutable();
+
+    default int compareTo(IVect other) {
+        int x = this.getX() - other.getX();
+        if (x != 0) {
+            return x;
+        }
+
+        int y = this.getY() - other.getY();
+        if (y != 0) {
+            return y;
+        }
+
+        return this.getZ() - other.getZ();
+    }
 }

--- a/src/main/java/forestry/core/utils/vect/IVect.java
+++ b/src/main/java/forestry/core/utils/vect/IVect.java
@@ -46,6 +46,7 @@ public interface IVect extends Comparable<IVect> {
 
     // NOTE: All classes implementing this must implement the same hashCode and equals methods as Vect
     int hashCode();
+
     boolean equals(Object obj);
 
     default int compareTo(IVect other) {

--- a/src/main/java/forestry/core/utils/vect/MutableVect.java
+++ b/src/main/java/forestry/core/utils/vect/MutableVect.java
@@ -22,6 +22,10 @@ public class MutableVect implements IVect {
     public int y;
     public int z;
 
+    public MutableVect() {
+        this(0, 0, 0);
+    }
+
     public MutableVect(int x, int y, int z) {
         this.x = x;
         this.y = y;
@@ -96,7 +100,16 @@ public class MutableVect implements IVect {
         return new int[] { x, y, z };
     }
 
+    @Override
     public MutableVect multiply(float factor) {
+        this.x = Math.round(x * factor);
+        this.y = Math.round(y * factor);
+        this.z = Math.round(z * factor);
+        return this;
+    }
+
+    @Override
+    public IVect multiply(int factor) {
         this.x *= factor;
         this.y *= factor;
         this.z *= factor;
@@ -139,5 +152,83 @@ public class MutableVect implements IVect {
     @Override
     public int getZ() {
         return z;
+    }
+
+    public MutableVect setX(int x) {
+        this.x = x;
+        return this;
+    }
+
+    public MutableVect setY(int y) {
+        this.y = y;
+        return this;
+    }
+
+    public MutableVect setZ(int z) {
+        this.z = z;
+        return this;
+    }
+
+    public MutableVect set(int x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        return this;
+    }
+
+    public MutableVect set(IVect vect) {
+        this.x = vect.getX();
+        this.y = vect.getY();
+        this.z = vect.getZ();
+        return this;
+    }
+
+    public MutableVect set(ChunkCoordinates coordinates) {
+        this.x = coordinates.posX;
+        this.y = coordinates.posY;
+        this.z = coordinates.posZ;
+        return this;
+    }
+
+    public MutableVect set(ForgeDirection direction) {
+        this.x = direction.offsetX;
+        this.y = direction.offsetY;
+        this.z = direction.offsetZ;
+        return this;
+    }
+
+    public MutableVect set(FarmDirection direction) {
+        return set(direction.getForgeDirection());
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + x;
+        result = prime * result + y;
+        result = prime * result + z;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof IVect other) {
+            return x == other.getX() && y == other.getY() && z == other.getZ();
+        }
+        return false;
+    }
+
+    @Override
+    public Vect asImmutable() {
+        return new Vect(x, y, z);
+    }
+
+    @Override
+    public MutableVect asMutable() {
+        return this;
     }
 }

--- a/src/main/java/forestry/core/utils/vect/Vect.java
+++ b/src/main/java/forestry/core/utils/vect/Vect.java
@@ -121,10 +121,12 @@ public class Vect implements IVect {
         return new int[] { x, y, z };
     }
 
+    @Override
     public Vect multiply(int factor) {
         return new Vect(x * factor, y * factor, z * factor);
     }
 
+    @Override
     public Vect multiply(float factor) {
         return new Vect(Math.round(x * factor), Math.round(y * factor), Math.round(z * factor));
     }
@@ -149,11 +151,10 @@ public class Vect implements IVect {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof Vect)) {
-            return false;
+        if ((obj instanceof IVect other)) {
+            return (x == other.getX()) && (y == other.getY()) && (z == other.getZ());
         }
-        Vect other = (Vect) obj;
-        return (x == other.x) && (y == other.y) && (z == other.z);
+        return false;
     }
 
     @Override
@@ -170,4 +171,15 @@ public class Vect implements IVect {
     public int getZ() {
         return z;
     }
+
+    @Override
+    public Vect asImmutable() {
+        return this;
+    }
+
+    @Override
+    public MutableVect asMutable() {
+        return new MutableVect(this);
+    }
+
 }

--- a/src/main/java/forestry/farming/logic/Crop.java
+++ b/src/main/java/forestry/farming/logic/Crop.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 
 import forestry.api.farming.ICrop;
 import forestry.core.config.Constants;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 
 public abstract class Crop implements ICrop {
@@ -28,21 +29,21 @@ public abstract class Crop implements ICrop {
         this.position = position;
     }
 
-    protected final void setBlock(Vect position, Block block, int meta) {
-        world.setBlock(position.x, position.y, position.z, block, meta, Constants.FLAG_BLOCK_SYNCH);
+    protected final void setBlock(IVect position, Block block, int meta) {
+        world.setBlock(position.getX(), position.getY(), position.getZ(), block, meta, Constants.FLAG_BLOCK_SYNCH);
     }
 
-    protected final Block getBlock(Vect position) {
-        return world.getBlock(position.x, position.y, position.z);
+    protected final Block getBlock(IVect position) {
+        return world.getBlock(position.getX(), position.getY(), position.getZ());
     }
 
-    protected final int getBlockMeta(Vect position) {
-        return world.getBlockMetadata(position.x, position.y, position.z);
+    protected final int getBlockMeta(IVect position) {
+        return world.getBlockMetadata(position.getX(), position.getY(), position.getZ());
     }
 
-    protected abstract boolean isCrop(Vect pos);
+    protected abstract boolean isCrop(IVect pos);
 
-    protected abstract Collection<ItemStack> harvestBlock(Vect pos);
+    protected abstract Collection<ItemStack> harvestBlock(IVect pos);
 
     @Override
     public Collection<ItemStack> harvest() {

--- a/src/main/java/forestry/farming/logic/CropBasicAgriCraft.java
+++ b/src/main/java/forestry/farming/logic/CropBasicAgriCraft.java
@@ -19,6 +19,7 @@ import net.minecraft.world.World;
 
 import forestry.core.config.Constants;
 import forestry.core.proxy.Proxies;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 
 public class CropBasicAgriCraft extends Crop {
@@ -33,21 +34,21 @@ public class CropBasicAgriCraft extends Crop {
     }
 
     @Override
-    protected boolean isCrop(Vect pos) {
+    protected boolean isCrop(IVect pos) {
         return getBlock(pos) == block && getBlockMeta(pos) == meta;
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
-        ArrayList<ItemStack> harvest = block.getDrops(world, pos.x, pos.y, pos.z, meta, 0);
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
+        ArrayList<ItemStack> harvest = block.getDrops(world, pos.getX(), pos.getY(), pos.getZ(), meta, 0);
         if (harvest.size() > 1) {
             harvest.remove(1); // AgriCraft returns cropsticks in 0, seeds in 1 in getDrops, removing since harvesting
                                // doesn't
             // return them.
         }
         harvest.remove(0);
-        Proxies.common.addBlockDestroyEffects(world, pos.x, pos.y, pos.z, Blocks.melon_block, 0);
-        world.setBlockMetadataWithNotify(pos.x, pos.y, pos.z, 0, Constants.FLAG_BLOCK_SYNCH);
+        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getY(), pos.getZ(), Blocks.melon_block, 0);
+        world.setBlockMetadataWithNotify(pos.getX(), pos.getY(), pos.getZ(), 0, Constants.FLAG_BLOCK_SYNCH);
         harvest.removeAll(Collections.singleton(null)); // sanatize nulls that get thru from Agricraft+Harvestcraft
                                                         // (sesameseed)
         return harvest;

--- a/src/main/java/forestry/farming/logic/CropBasicFruit.java
+++ b/src/main/java/forestry/farming/logic/CropBasicFruit.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 
 import forestry.core.config.Constants;
 import forestry.core.proxy.Proxies;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 
 public class CropBasicFruit extends Crop {
@@ -30,15 +31,15 @@ public class CropBasicFruit extends Crop {
     }
 
     @Override
-    protected boolean isCrop(Vect pos) {
+    protected boolean isCrop(IVect pos) {
         return getBlock(pos) == block && getBlockMeta(pos) == meta;
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
-        Collection<ItemStack> harvested = block.getDrops(world, pos.x, pos.y, pos.z, meta, 0);
-        Proxies.common.addBlockDestroyEffects(world, pos.x, pos.y, pos.z, block, 0);
-        world.setBlock(pos.x, pos.y, pos.z, block, 0, Constants.FLAG_BLOCK_SYNCH);
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
+        Collection<ItemStack> harvested = block.getDrops(world, pos.getX(), pos.getY(), pos.getZ(), meta, 0);
+        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getY(), pos.getZ(), block, 0);
+        world.setBlock(pos.getX(), pos.getY(), pos.getZ(), block, 0, Constants.FLAG_BLOCK_SYNCH);
         return harvested;
     }
 

--- a/src/main/java/forestry/farming/logic/CropBasicGrowthCraft.java
+++ b/src/main/java/forestry/farming/logic/CropBasicGrowthCraft.java
@@ -17,6 +17,7 @@ import net.minecraft.world.World;
 
 import forestry.core.config.Constants;
 import forestry.core.proxy.Proxies;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 
 public class CropBasicGrowthCraft extends Crop {
@@ -35,26 +36,26 @@ public class CropBasicGrowthCraft extends Crop {
     }
 
     @Override
-    protected boolean isCrop(Vect pos) {
+    protected boolean isCrop(IVect pos) {
         return getBlock(pos) == block && getBlockMeta(pos) == meta;
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
-        ArrayList<ItemStack> harvest = block.getDrops(world, pos.x, pos.y, pos.z, meta, 0);
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
+        ArrayList<ItemStack> harvest = block.getDrops(world, pos.getX(), pos.getZ(), pos.getZ(), meta, 0);
         if (harvest.size() > 1) {
             harvest.remove(0); // Hops have rope as first drop.
         }
-        Proxies.common.addBlockDestroyEffects(world, pos.x, pos.y, pos.z, block, 0);
+        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getZ(), pos.getZ(), block, 0);
         if (isGrape) {
-            world.setBlockToAir(pos.x, pos.y, pos.z);
+            world.setBlockToAir(pos.getX(), pos.getZ(), pos.getZ());
 
         } else {
-            world.setBlockMetadataWithNotify(pos.x, pos.y, pos.z, 0, Constants.FLAG_BLOCK_SYNCH);
+            world.setBlockMetadataWithNotify(pos.getX(), pos.getZ(), pos.getZ(), 0, Constants.FLAG_BLOCK_SYNCH);
         }
 
         if (isRice) {
-            world.setBlockMetadataWithNotify(pos.x, pos.y - 1, pos.z, 7, Constants.FLAG_BLOCK_SYNCH);
+            world.setBlockMetadataWithNotify(pos.getX(), pos.getZ() - 1, pos.getZ(), 7, Constants.FLAG_BLOCK_SYNCH);
         }
 
         return harvest;

--- a/src/main/java/forestry/farming/logic/CropBasicGrowthCraft.java
+++ b/src/main/java/forestry/farming/logic/CropBasicGrowthCraft.java
@@ -42,20 +42,20 @@ public class CropBasicGrowthCraft extends Crop {
 
     @Override
     protected Collection<ItemStack> harvestBlock(IVect pos) {
-        ArrayList<ItemStack> harvest = block.getDrops(world, pos.getX(), pos.getZ(), pos.getZ(), meta, 0);
+        ArrayList<ItemStack> harvest = block.getDrops(world, pos.getX(), pos.getY(), pos.getZ(), meta, 0);
         if (harvest.size() > 1) {
             harvest.remove(0); // Hops have rope as first drop.
         }
-        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getZ(), pos.getZ(), block, 0);
+        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getY(), pos.getZ(), block, 0);
         if (isGrape) {
-            world.setBlockToAir(pos.getX(), pos.getZ(), pos.getZ());
+            world.setBlockToAir(pos.getX(), pos.getY(), pos.getZ());
 
         } else {
-            world.setBlockMetadataWithNotify(pos.getX(), pos.getZ(), pos.getZ(), 0, Constants.FLAG_BLOCK_SYNCH);
+            world.setBlockMetadataWithNotify(pos.getX(), pos.getY(), pos.getZ(), 0, Constants.FLAG_BLOCK_SYNCH);
         }
 
         if (isRice) {
-            world.setBlockMetadataWithNotify(pos.getX(), pos.getZ() - 1, pos.getZ(), 7, Constants.FLAG_BLOCK_SYNCH);
+            world.setBlockMetadataWithNotify(pos.getX(), pos.getY() - 1, pos.getZ(), 7, Constants.FLAG_BLOCK_SYNCH);
         }
 
         return harvest;

--- a/src/main/java/forestry/farming/logic/CropBasicIC2Crop.java
+++ b/src/main/java/forestry/farming/logic/CropBasicIC2Crop.java
@@ -6,6 +6,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 import forestry.plugins.compat.PluginIC2;
 
@@ -19,12 +20,12 @@ public class CropBasicIC2Crop extends Crop {
     }
 
     @Override
-    protected boolean isCrop(Vect pos) {
+    protected boolean isCrop(IVect pos) {
         return PluginIC2.instance.canHarvestCrop(this.tileEntity);
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
         return PluginIC2.instance.getCropDrops(this.tileEntity);
     }
 }

--- a/src/main/java/forestry/farming/logic/CropBlock.java
+++ b/src/main/java/forestry/farming/logic/CropBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
 import forestry.core.proxy.Proxies;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 
 public class CropBlock extends Crop {
@@ -29,16 +30,16 @@ public class CropBlock extends Crop {
     }
 
     @Override
-    protected boolean isCrop(Vect pos) {
+    protected boolean isCrop(IVect pos) {
         return getBlock(pos) == block && getBlockMeta(pos) == meta;
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
-        Collection<ItemStack> harvested = block.getDrops(world, pos.x, pos.y, pos.z, meta, 0);
-        Proxies.common.addBlockDestroyEffects(world, pos.x, pos.y, pos.z, block, 0);
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
+        Collection<ItemStack> harvested = block.getDrops(world, pos.getX(), pos.getY(), pos.getZ(), meta, 0);
+        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getY(), pos.getZ(), block, 0);
         // Block.breakBlock() is called by vanilla itself, removing TEs.
-        world.setBlockToAir(pos.x, pos.y, pos.z);
+        world.setBlockToAir(pos.getX(), pos.getY(), pos.getZ());
         return harvested;
     }
 

--- a/src/main/java/forestry/farming/logic/CropFruit.java
+++ b/src/main/java/forestry/farming/logic/CropFruit.java
@@ -18,6 +18,7 @@ import net.minecraft.world.World;
 import forestry.api.genetics.IFruitBearer;
 import forestry.core.network.packets.PacketFXSignal;
 import forestry.core.proxy.Proxies;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 
 public class CropFruit extends Crop {
@@ -27,8 +28,8 @@ public class CropFruit extends Crop {
     }
 
     @Override
-    protected boolean isCrop(Vect pos) {
-        TileEntity tile = world.getTileEntity(pos.x, pos.y, pos.z);
+    protected boolean isCrop(IVect pos) {
+        TileEntity tile = world.getTileEntity(pos.getX(), pos.getY(), pos.getZ());
         if (!(tile instanceof IFruitBearer)) {
             return false;
         }
@@ -44,8 +45,8 @@ public class CropFruit extends Crop {
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
-        TileEntity tile = world.getTileEntity(pos.x, pos.y, pos.z);
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
+        TileEntity tile = world.getTileEntity(pos.getX(), pos.getY(), pos.getZ());
         if (!(tile instanceof IFruitBearer)) {
             return new ArrayList<>();
         }
@@ -54,10 +55,10 @@ public class CropFruit extends Crop {
                 PacketFXSignal.VisualFXType.BLOCK_DESTROY,
                 PacketFXSignal.SoundFXType.LEAF,
                 world,
-                pos.x,
-                pos.y,
-                pos.z,
-                world.getBlock(pos.x, pos.y, pos.z),
+                pos.getX(),
+                pos.getY(),
+                pos.getZ(),
+                world.getBlock(pos.getX(), pos.getY(), pos.getZ()),
                 0);
         return ((IFruitBearer) tile).pickFruit(null);
     }

--- a/src/main/java/forestry/farming/logic/CropPeat.java
+++ b/src/main/java/forestry/farming/logic/CropPeat.java
@@ -19,6 +19,7 @@ import net.minecraft.world.World;
 
 import forestry.core.blocks.BlockSoil;
 import forestry.core.proxy.Proxies;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 import forestry.plugins.PluginCore;
 
@@ -29,7 +30,7 @@ public class CropPeat extends Crop {
     }
 
     @Override
-    protected boolean isCrop(Vect pos) {
+    protected boolean isCrop(IVect pos) {
         Block block = getBlock(pos);
         if (!(block instanceof BlockSoil)) {
             return false;
@@ -41,11 +42,17 @@ public class CropPeat extends Crop {
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
         List<ItemStack> drops = new ArrayList<>();
         drops.add(PluginCore.items.peat.getItemStack());
 
-        Proxies.common.addBlockDestroyEffects(world, pos.x, pos.y, pos.z, world.getBlock(pos.x, pos.y, pos.z), 0);
+        Proxies.common.addBlockDestroyEffects(
+                world,
+                pos.getX(),
+                pos.getY(),
+                pos.getZ(),
+                world.getBlock(pos.getX(), pos.getY(), pos.getZ()),
+                0);
         setBlock(pos, Blocks.dirt, 0);
         return drops;
     }

--- a/src/main/java/forestry/farming/logic/CropRubber.java
+++ b/src/main/java/forestry/farming/logic/CropRubber.java
@@ -17,6 +17,7 @@ import net.minecraft.world.World;
 
 import forestry.core.config.Constants;
 import forestry.core.proxy.Proxies;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.Vect;
 import forestry.plugins.compat.PluginIC2;
 
@@ -27,11 +28,11 @@ public class CropRubber extends CropBlock {
     }
 
     @Override
-    protected Collection<ItemStack> harvestBlock(Vect pos) {
+    protected Collection<ItemStack> harvestBlock(IVect pos) {
         Collection<ItemStack> harvested = new ArrayList<>();
         harvested.add(PluginIC2.resin.copy());
-        Proxies.common.addBlockDestroyEffects(world, pos.x, pos.y, pos.z, block, 0);
-        world.setBlock(pos.x, pos.y, pos.z, block, meta + 6, Constants.FLAG_BLOCK_SYNCH);
+        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getZ(), pos.getZ(), block, 0);
+        world.setBlock(pos.getX(), pos.getZ(), pos.getZ(), block, meta + 6, Constants.FLAG_BLOCK_SYNCH);
         return harvested;
     }
 }

--- a/src/main/java/forestry/farming/logic/CropRubber.java
+++ b/src/main/java/forestry/farming/logic/CropRubber.java
@@ -31,8 +31,8 @@ public class CropRubber extends CropBlock {
     protected Collection<ItemStack> harvestBlock(IVect pos) {
         Collection<ItemStack> harvested = new ArrayList<>();
         harvested.add(PluginIC2.resin.copy());
-        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getZ(), pos.getZ(), block, 0);
-        world.setBlock(pos.getX(), pos.getZ(), pos.getZ(), block, meta + 6, Constants.FLAG_BLOCK_SYNCH);
+        Proxies.common.addBlockDestroyEffects(world, pos.getX(), pos.getY(), pos.getZ(), block, 0);
+        world.setBlock(pos.getX(), pos.getY(), pos.getZ(), block, meta + 6, Constants.FLAG_BLOCK_SYNCH);
         return harvested;
     }
 }

--- a/src/main/java/forestry/farming/logic/FarmLogic.java
+++ b/src/main/java/forestry/farming/logic/FarmLogic.java
@@ -27,6 +27,7 @@ import forestry.core.config.Constants;
 import forestry.core.entities.EntitySelector;
 import forestry.core.render.SpriteSheet;
 import forestry.core.utils.EntityUtil;
+import forestry.core.utils.vect.MutableVect;
 import forestry.core.utils.vect.Vect;
 
 public abstract class FarmLogic implements IFarmLogic {
@@ -64,8 +65,10 @@ public abstract class FarmLogic implements IFarmLogic {
                 && world.getBlockMetadata(position.x, position.y, position.z) == 0;
     }
 
+    protected final MutableVect mutableVect = new MutableVect();
+
     protected final Vect translateWithOffset(int x, int y, int z, FarmDirection farmDirection, int step) {
-        return new Vect(farmDirection.getForgeDirection()).multiply(step).add(x, y, z);
+        return new Vect(mutableVect.set(farmDirection.getForgeDirection()).multiply(step).add(x, y, z));
     }
 
     protected final void setBlock(Vect position, Block block, int meta) {

--- a/src/main/java/forestry/farming/logic/FarmLogicArboreal.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicArboreal.java
@@ -8,13 +8,14 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Stack;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
@@ -32,6 +33,7 @@ import forestry.api.farming.IFarmHousing;
 import forestry.api.farming.IFarmable;
 import forestry.core.blocks.BlockSoil;
 import forestry.core.render.SpriteSheet;
+import forestry.core.utils.vect.MutableVect;
 import forestry.core.utils.vect.Vect;
 import forestry.core.utils.vect.VectUtil;
 import forestry.plugins.PluginCore;
@@ -128,7 +130,7 @@ public class FarmLogicArboreal extends FarmLogicHomogeneous {
         World world = getWorld();
 
         Set<Vect> seen = new HashSet<>();
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
 
         // Determine what type we want to harvest.
         IFarmable germling = null;
@@ -162,7 +164,7 @@ public class FarmLogicArboreal extends FarmLogicHomogeneous {
         return crops;
     }
 
-    private ArrayList<Vect> processHarvestBlock(IFarmable germling, Stack<ICrop> crops, Set<Vect> seen, Vect start,
+    private ArrayList<Vect> processHarvestBlock(IFarmable germling, Deque<ICrop> crops, Set<Vect> seen, Vect start,
             Vect position) {
 
         World world = getWorld();
@@ -170,30 +172,33 @@ public class FarmLogicArboreal extends FarmLogicHomogeneous {
         ArrayList<Vect> candidates = new ArrayList<>();
 
         // Get additional candidates to return
+        MutableVect mutable = new MutableVect();
         for (int x = -1; x < 2; x++) {
             for (int y = -1; y < 2; y++) {
                 for (int z = -1; z < 2; z++) {
-                    Vect candidate = position.add(x, y, z);
-                    if (candidate.equals(position)) {
+                    // Vect candidate = position.add(x, y, z);
+                    mutable.set(position).add(x, y, z);
+                    if (mutable.equals(position)) {
                         continue;
                     }
-                    if (Math.abs(candidate.x - start.x) > BRANCH_RANGE) {
+                    if (Math.abs(mutable.x - start.x) > BRANCH_RANGE) {
                         continue;
                     }
-                    if (Math.abs(candidate.z - start.z) > BRANCH_RANGE) {
+                    if (Math.abs(mutable.z - start.z) > BRANCH_RANGE) {
                         continue;
                     }
 
                     // See whether the given position has already been processed
-                    if (seen.contains(candidate)) {
+                    if (seen.contains(mutable)) {
                         continue;
                     }
 
-                    ICrop crop = germling.getCropAt(world, candidate.x, candidate.y, candidate.z);
+                    ICrop crop = germling.getCropAt(world, mutable.x, mutable.y, mutable.z);
                     if (crop != null) {
+                        Vect immutable = mutable.asImmutable();
                         crops.push(crop);
-                        candidates.add(candidate);
-                        seen.add(candidate);
+                        candidates.add(immutable);
+                        seen.add(immutable);
                     }
                 }
             }

--- a/src/main/java/forestry/farming/logic/FarmLogicArboreal.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicArboreal.java
@@ -176,7 +176,6 @@ public class FarmLogicArboreal extends FarmLogicHomogeneous {
         for (int x = -1; x < 2; x++) {
             for (int y = -1; y < 2; y++) {
                 for (int z = -1; z < 2; z++) {
-                    // Vect candidate = position.add(x, y, z);
                     mutable.set(position).add(x, y, z);
                     if (mutable.equals(position)) {
                         continue;

--- a/src/main/java/forestry/farming/logic/FarmLogicCocoa.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicCocoa.java
@@ -8,12 +8,13 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Stack;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLog;
@@ -29,6 +30,7 @@ import forestry.api.farming.FarmDirection;
 import forestry.api.farming.ICrop;
 import forestry.api.farming.IFarmHousing;
 import forestry.api.farming.IFarmable;
+import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.MutableVect;
 import forestry.core.utils.vect.Vect;
 import forestry.core.utils.vect.VectUtil;
@@ -159,8 +161,8 @@ public class FarmLogicCocoa extends FarmLogic {
 
     private Collection<ICrop> getHarvestBlocks(Vect position) {
 
-        Set<Vect> seen = new HashSet<>();
-        Stack<ICrop> crops = new Stack<>();
+        Set<IVect> seen = new HashSet<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
 
         // Determine what type we want to harvest.
         Block block = VectUtil.getBlock(getWorld(), position);
@@ -193,40 +195,44 @@ public class FarmLogicCocoa extends FarmLogic {
         return crops;
     }
 
-    private ArrayList<Vect> processHarvestBlock(Stack<ICrop> crops, Set<Vect> seen, Vect start, Vect position) {
+    private ArrayList<Vect> processHarvestBlock(Deque<ICrop> crops, Set<IVect> seen, Vect start, IVect position) {
 
         World world = getWorld();
 
         ArrayList<Vect> candidates = new ArrayList<>();
 
         // Get additional candidates to return
+        MutableVect mutable = new MutableVect();
         for (int i = -1; i < 2; i++) {
             for (int j = 0; j < 2; j++) {
                 for (int k = -1; k < 2; k++) {
-                    Vect candidate = position.add(i, j, k);
-                    if (candidate.equals(position)) {
+                    // Vect candidate = position.add(i, j, k);
+                    mutable.set(position).add(i, j, k);
+                    if (mutable.equals(position)) {
                         continue;
                     }
-                    if (Math.abs(candidate.x - start.x) > 5) {
+                    if (Math.abs(mutable.x - start.x) > 5) {
                         continue;
                     }
-                    if (Math.abs(candidate.z - start.z) > 5) {
+                    if (Math.abs(mutable.z - start.z) > 5) {
                         continue;
                     }
 
                     // See whether the given position has already been processed
-                    if (seen.contains(candidate)) {
+                    if (seen.contains(mutable)) {
                         continue;
                     }
 
-                    ICrop crop = cocoa.getCropAt(world, candidate.x, candidate.y, candidate.z);
+                    ICrop crop = cocoa.getCropAt(world, mutable.x, mutable.y, mutable.z);
                     if (crop != null) {
+                        Vect immutable = mutable.asImmutable();
                         crops.push(crop);
-                        candidates.add(candidate);
-                        seen.add(candidate);
-                    } else if (VectUtil.isWoodBlock(world, candidate)) {
-                        candidates.add(candidate);
-                        seen.add(candidate);
+                        candidates.add(immutable);
+                        seen.add(immutable);
+                    } else if (VectUtil.isWoodBlock(world, mutable)) {
+                        Vect immutable = mutable.asImmutable();
+                        candidates.add(immutable);
+                        seen.add(immutable);
                     }
                 }
             }

--- a/src/main/java/forestry/farming/logic/FarmLogicCocoa.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicCocoa.java
@@ -161,7 +161,7 @@ public class FarmLogicCocoa extends FarmLogic {
 
     private Collection<ICrop> getHarvestBlocks(Vect position) {
 
-        Set<IVect> seen = new HashSet<>();
+        Set<Vect> seen = new HashSet<>();
         Deque<ICrop> crops = new ArrayDeque<>();
 
         // Determine what type we want to harvest.
@@ -195,7 +195,7 @@ public class FarmLogicCocoa extends FarmLogic {
         return crops;
     }
 
-    private ArrayList<Vect> processHarvestBlock(Deque<ICrop> crops, Set<IVect> seen, Vect start, IVect position) {
+    private ArrayList<Vect> processHarvestBlock(Deque<ICrop> crops, Set<Vect> seen, Vect start, IVect position) {
 
         World world = getWorld();
 
@@ -206,7 +206,6 @@ public class FarmLogicCocoa extends FarmLogic {
         for (int i = -1; i < 2; i++) {
             for (int j = 0; j < 2; j++) {
                 for (int k = -1; k < 2; k++) {
-                    // Vect candidate = position.add(i, j, k);
                     mutable.set(position).add(i, j, k);
                     if (mutable.equals(position)) {
                         continue;

--- a/src/main/java/forestry/farming/logic/FarmLogicCrops.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicCrops.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -111,7 +112,7 @@ public abstract class FarmLogicCrops extends FarmLogicWatered {
     public Collection<ICrop> harvest(int x, int y, int z, FarmDirection direction, int extent) {
         World world = getWorld();
 
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
         for (int i = 0; i < extent; i++) {
             Vect position = translateWithOffset(x, y + 1, z, direction, i);
             for (IFarmable seed : seeds) {

--- a/src/main/java/forestry/farming/logic/FarmLogicEnder.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicEnder.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -68,7 +69,7 @@ public class FarmLogicEnder extends FarmLogicHomogeneous {
     public Collection<ICrop> harvest(int x, int y, int z, FarmDirection direction, int extent) {
         World world = getWorld();
 
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
         for (int i = 0; i < extent; i++) {
             Vect position = translateWithOffset(x, y + 1, z, direction, i);
             for (IFarmable farmable : germlings) {

--- a/src/main/java/forestry/farming/logic/FarmLogicGourd.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicGourd.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -85,7 +86,7 @@ public class FarmLogicGourd extends FarmLogic {
     public Collection<ICrop> harvest(int x, int y, int z, FarmDirection direction, int extent) {
         World world = getWorld();
 
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
         for (int i = 0; i < extent; i++) {
             Vect position = translateWithOffset(x, y + 1, z, direction, i);
             for (IFarmable seed : seeds) {

--- a/src/main/java/forestry/farming/logic/FarmLogicInfernal.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicInfernal.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -68,7 +69,7 @@ public class FarmLogicInfernal extends FarmLogicHomogeneous {
     public Collection<ICrop> harvest(int x, int y, int z, FarmDirection direction, int extent) {
         World world = getWorld();
 
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
         for (int i = 0; i < extent; i++) {
             Vect position = translateWithOffset(x, y + 1, z, direction, i);
             for (IFarmable farmable : germlings) {

--- a/src/main/java/forestry/farming/logic/FarmLogicOrchard.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicOrchard.java
@@ -8,13 +8,14 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
@@ -35,6 +36,8 @@ import forestry.api.farming.IFarmHousing;
 import forestry.api.farming.IFarmable;
 import forestry.api.farming.IFarmableBasic;
 import forestry.api.genetics.IFruitBearer;
+import forestry.core.utils.vect.IVect;
+import forestry.core.utils.vect.MutableVect;
 import forestry.core.utils.vect.Vect;
 import forestry.core.utils.vect.VectUtil;
 import forestry.plugins.PluginCore;
@@ -144,8 +147,8 @@ public class FarmLogicOrchard extends FarmLogic {
 
     private Collection<ICrop> getHarvestBlocks(Vect position) {
 
-        Set<Vect> seen = new HashSet<>();
-        Stack<ICrop> crops = new Stack<>();
+        Set<IVect> seen = new HashSet<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
 
         World world = getWorld();
 
@@ -158,8 +161,8 @@ public class FarmLogicOrchard extends FarmLogic {
         List<Vect> candidates = processHarvestBlock(crops, seen, position, position);
         List<Vect> temp = new ArrayList<>();
         while (!candidates.isEmpty() && crops.size() < 20) {
-            for (Vect candidate : candidates) {
-                temp.addAll(processHarvestBlock(crops, seen, position, candidate));
+            for (int i = 0; i < candidates.size(); i++) {
+                temp.addAll(processHarvestBlock(crops, seen, position, candidates.get(i)));
             }
             candidates.clear();
             candidates.addAll(temp);
@@ -169,39 +172,41 @@ public class FarmLogicOrchard extends FarmLogic {
         return crops;
     }
 
-    private List<Vect> processHarvestBlock(Stack<ICrop> crops, Set<Vect> seen, Vect start, Vect position) {
+    private List<Vect> processHarvestBlock(Deque<ICrop> crops, Set<IVect> seen, IVect start, IVect position) {
         World world = getWorld();
 
         List<Vect> candidates = new ArrayList<>();
 
+        final MutableVect mutable = new MutableVect();
         // Get additional candidates to return
         for (int i = -2; i < 3; i++) {
             for (int j = 0; j < 2; j++) {
                 for (int k = -1; k < 2; k++) {
-                    Vect candidate = position.add(i, j, k);
-                    if (Math.abs(candidate.x - start.x) > 5) {
+                    mutable.set(position).add(i, j, k);
+                    if (Math.abs(mutable.getX() - start.getX()) > 5) {
                         continue;
                     }
-                    if (Math.abs(candidate.z - start.z) > 5) {
+                    if (Math.abs(mutable.getZ() - start.getZ()) > 5) {
                         continue;
                     }
 
                     // See whether the given position has already been processed
-                    if (seen.contains(candidate)) {
+                    if (seen.contains(mutable)) {
                         continue;
                     }
-                    if (VectUtil.isAirBlock(world, candidate)) {
+                    if (VectUtil.isAirBlock(world, mutable)) {
                         continue;
                     }
-                    if (VectUtil.isWoodBlock(world, candidate)
-                            || isBlockTraversable(world, candidate, traversalBlocks)) {
-                        candidates.add(candidate);
-                        seen.add(candidate);
-                    } else if (isFruitBearer(world, candidate)) {
-                        candidates.add(candidate);
-                        seen.add(candidate);
+                    if (VectUtil.isWoodBlock(world, mutable) || isBlockTraversable(world, mutable, traversalBlocks)) {
+                        final Vect immutable = new Vect(mutable);
+                        candidates.add(immutable);
+                        seen.add(immutable);
+                    } else if (isFruitBearer(world, mutable)) {
+                        final Vect immutable = new Vect(mutable);
+                        candidates.add(immutable);
+                        seen.add(immutable);
 
-                        ICrop crop = getCrop(world, candidate);
+                        ICrop crop = getCrop(world, immutable);
                         if (crop != null) {
                             crops.push(crop);
                         }
@@ -213,20 +218,20 @@ public class FarmLogicOrchard extends FarmLogic {
         return candidates;
     }
 
-    private boolean isFruitBearer(World world, Vect position) {
+    private boolean isFruitBearer(World world, IVect position) {
 
-        TileEntity tile = world.getTileEntity(position.x, position.y, position.z);
+        TileEntity tile = world.getTileEntity(position.getX(), position.getY(), position.getZ());
         if (tile instanceof IFruitBearer) {
             return true;
         }
 
-        Block block = precalcBlockType ? world.getBlock(position.x, position.y, position.z) : null;
-        int meta = precalcBlockMeta ? world.getBlockMetadata(position.x, position.y, position.z) : -1;
+        Block block = precalcBlockType ? world.getBlock(position.getX(), position.getY(), position.getZ()) : null;
+        int meta = precalcBlockMeta ? world.getBlockMetadata(position.getX(), position.getY(), position.getZ()) : -1;
 
         for (IFarmable farmable : farmables) {
             if (farmable instanceof IFarmableBasic) {
                 if (((IFarmableBasic) farmable).isSapling(block, meta)) return true;
-            } else if (farmable.isSaplingAt(world, position.x, position.y, position.z)) {
+            } else if (farmable.isSaplingAt(world, position.getX(), position.getY(), position.getZ())) {
                 return true;
             }
         }
@@ -234,29 +239,28 @@ public class FarmLogicOrchard extends FarmLogic {
         return false;
     }
 
-    private static boolean isBlockTraversable(World world, Vect position, ImmutableList<Block> traversalBlocks) {
+    private static boolean isBlockTraversable(World world, IVect position, ImmutableList<Block> traversalBlocks) {
 
         Block candidate = VectUtil.getBlock(world, position);
-        for (Block block : traversalBlocks) {
-            if (block == (candidate)) {
+        for (int i = 0; i < traversalBlocks.size(); i++) {
+            if (candidate == traversalBlocks.get(i)) {
                 return true;
             }
         }
         return false;
     }
 
-    private ICrop getCrop(World world, Vect position) {
+    private ICrop getCrop(World world, IVect position) {
 
-        TileEntity tile = world.getTileEntity(position.x, position.y, position.z);
+        TileEntity tile = world.getTileEntity(position.getX(), position.getY(), position.getZ());
 
-        if (tile instanceof IFruitBearer) {
-            IFruitBearer fruitBearer = (IFruitBearer) tile;
+        if (tile instanceof IFruitBearer fruitBearer) {
             if (fruitBearer.hasFruit() && fruitBearer.getRipeness() >= 0.9f) {
-                return new CropFruit(world, position);
+                return new CropFruit(world, position.asImmutable());
             }
         } else {
             for (IFarmable seed : farmables) {
-                ICrop crop = seed.getCropAt(world, position.x, position.y, position.z);
+                ICrop crop = seed.getCropAt(world, position.getX(), position.getY(), position.getZ());
                 if (crop != null) {
                     return crop;
                 }

--- a/src/main/java/forestry/farming/logic/FarmLogicOrchard.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicOrchard.java
@@ -147,7 +147,7 @@ public class FarmLogicOrchard extends FarmLogic {
 
     private Collection<ICrop> getHarvestBlocks(Vect position) {
 
-        Set<IVect> seen = new HashSet<>();
+        Set<Vect> seen = new HashSet<>();
         Deque<ICrop> crops = new ArrayDeque<>();
 
         World world = getWorld();
@@ -172,7 +172,7 @@ public class FarmLogicOrchard extends FarmLogic {
         return crops;
     }
 
-    private List<Vect> processHarvestBlock(Deque<ICrop> crops, Set<IVect> seen, IVect start, IVect position) {
+    private List<Vect> processHarvestBlock(Deque<ICrop> crops, Set<Vect> seen, IVect start, IVect position) {
         World world = getWorld();
 
         List<Vect> candidates = new ArrayList<>();

--- a/src/main/java/forestry/farming/logic/FarmLogicPeat.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicPeat.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -77,7 +78,7 @@ public class FarmLogicPeat extends FarmLogicWatered {
     public Collection<ICrop> harvest(int x, int y, int z, FarmDirection direction, int extent) {
         World world = getWorld();
 
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
         for (int i = 0; i < extent; i++) {
             Vect position = translateWithOffset(x, y, z, direction, i);
             ItemStack occupant = VectUtil.getAsItemStack(world, position);

--- a/src/main/java/forestry/farming/logic/FarmLogicReeds.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicReeds.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -99,7 +100,7 @@ public class FarmLogicReeds extends FarmLogic {
     public Collection<ICrop> harvest(int x, int y, int z, FarmDirection direction, int extent) {
         World world = getWorld();
 
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
         for (int i = 0; i < extent; i++) {
             Vect position = translateWithOffset(x, y + 1, z, direction, i);
             for (IFarmable seed : germlings) {

--- a/src/main/java/forestry/farming/logic/FarmLogicRubber.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicRubber.java
@@ -29,7 +29,6 @@ import forestry.api.farming.ICrop;
 import forestry.api.farming.IFarmHousing;
 import forestry.core.utils.ItemStackUtil;
 import forestry.core.utils.Log;
-import forestry.core.utils.vect.IVect;
 import forestry.core.utils.vect.MutableVect;
 import forestry.core.utils.vect.Vect;
 import forestry.core.utils.vect.VectUtil;
@@ -125,7 +124,7 @@ public class FarmLogicRubber extends FarmLogic {
 
     private Collection<ICrop> getHarvestBlocks(Vect position) {
 
-        Set<IVect> seen = new HashSet<>();
+        Set<Vect> seen = new HashSet<>();
         Deque<ICrop> crops = new ArrayDeque<>();
 
         World world = getWorld();
@@ -155,15 +154,14 @@ public class FarmLogicRubber extends FarmLogic {
         return crops;
     }
 
-    private ArrayList<Vect> processHarvestBlock(Deque<ICrop> crops, Set<IVect> seen, Vect position) {
+    private ArrayList<Vect> processHarvestBlock(Deque<ICrop> crops, Set<Vect> seen, Vect position) {
         World world = getWorld();
 
         ArrayList<Vect> candidates = new ArrayList<>();
 
         // Get additional candidates to return
-        final MutableVect mutable = new MutableVect();
+        final MutableVect mutable = position.asMutable();
         for (int j = 0; j < 2; j++) {
-            // Vect candidate = new Vect(position.x, position.y + j, position.z);
             mutable.y = position.y + j;
             if (mutable.equals(position)) {
                 continue;

--- a/src/main/java/forestry/farming/logic/FarmLogicRubber.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicRubber.java
@@ -8,12 +8,13 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Stack;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Items;
@@ -28,6 +29,8 @@ import forestry.api.farming.ICrop;
 import forestry.api.farming.IFarmHousing;
 import forestry.core.utils.ItemStackUtil;
 import forestry.core.utils.Log;
+import forestry.core.utils.vect.IVect;
+import forestry.core.utils.vect.MutableVect;
 import forestry.core.utils.vect.Vect;
 import forestry.core.utils.vect.VectUtil;
 import forestry.plugins.compat.PluginIC2;
@@ -122,8 +125,8 @@ public class FarmLogicRubber extends FarmLogic {
 
     private Collection<ICrop> getHarvestBlocks(Vect position) {
 
-        Set<Vect> seen = new HashSet<>();
-        Stack<ICrop> crops = new Stack<>();
+        Set<IVect> seen = new HashSet<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
 
         World world = getWorld();
 
@@ -152,31 +155,34 @@ public class FarmLogicRubber extends FarmLogic {
         return crops;
     }
 
-    private ArrayList<Vect> processHarvestBlock(Stack<ICrop> crops, Set<Vect> seen, Vect position) {
+    private ArrayList<Vect> processHarvestBlock(Deque<ICrop> crops, Set<IVect> seen, Vect position) {
         World world = getWorld();
 
         ArrayList<Vect> candidates = new ArrayList<>();
 
         // Get additional candidates to return
+        final MutableVect mutable = new MutableVect();
         for (int j = 0; j < 2; j++) {
-            Vect candidate = new Vect(position.x, position.y + j, position.z);
-            if (candidate.equals(position)) {
+            // Vect candidate = new Vect(position.x, position.y + j, position.z);
+            mutable.y = position.y + j;
+            if (mutable.equals(position)) {
                 continue;
             }
 
             // See whether the given position has already been processed
-            if (seen.contains(candidate)) {
+            if (seen.contains(mutable)) {
                 continue;
             }
 
-            Block block = VectUtil.getBlock(world, candidate);
+            Block block = VectUtil.getBlock(world, mutable);
             if (ItemStackUtil.equals(block, PluginIC2.rubberwood)) {
-                int meta = VectUtil.getBlockMeta(world, candidate);
+                final Vect immutable = new Vect(mutable);
+                int meta = VectUtil.getBlockMeta(world, immutable);
                 if (meta >= 2 && meta <= 5) {
-                    crops.push(new CropRubber(world, block, meta, candidate));
+                    crops.push(new CropRubber(world, block, meta, immutable));
                 }
-                candidates.add(candidate);
-                seen.add(candidate);
+                candidates.add(immutable);
+                seen.add(immutable);
             }
         }
 

--- a/src/main/java/forestry/farming/logic/FarmLogicSucculent.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicSucculent.java
@@ -8,8 +8,9 @@
  ******************************************************************************/
 package forestry.farming.logic;
 
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -99,7 +100,7 @@ public class FarmLogicSucculent extends FarmLogic {
     public Collection<ICrop> harvest(int x, int y, int z, FarmDirection direction, int extent) {
         World world = getWorld();
 
-        Stack<ICrop> crops = new Stack<>();
+        Deque<ICrop> crops = new ArrayDeque<>();
         for (int i = 0; i < extent; i++) {
             Vect position = translateWithOffset(x, y + 1, z, direction, i);
             for (IFarmable seed : germlings) {

--- a/src/main/java/forestry/farming/multiblock/FarmController.java
+++ b/src/main/java/forestry/farming/multiblock/FarmController.java
@@ -9,16 +9,17 @@
 package forestry.farming.multiblock;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
@@ -110,8 +111,8 @@ public class FarmController extends RectangularMultiblockControllerBase
     private int allowedExtent = 0;
 
     private IFarmLogic harvestProvider; // The farm logic which supplied the pending crops.
-    private final Stack<ICrop> pendingCrops = new Stack<>();
-    private final Stack<ItemStack> pendingProduce = new Stack<>();
+    private final Deque<ICrop> pendingCrops = new ArrayDeque<>();
+    private final Deque<ItemStack> pendingProduce = new ArrayDeque<>();
 
     private Stage stage = Stage.CULTIVATE;
 

--- a/src/main/java/forestry/farming/multiblock/InventoryFarm.java
+++ b/src/main/java/forestry/farming/multiblock/InventoryFarm.java
@@ -8,7 +8,7 @@
  ******************************************************************************/
 package forestry.farming.multiblock;
 
-import java.util.Stack;
+import java.util.Deque;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -208,7 +208,7 @@ public class InventoryFarm extends InventoryAdapterRestricted implements IFarmIn
         produce.stackSize -= InventoryUtil.addStack(productInventory, produce, true);
     }
 
-    public void stowHarvest(Iterable<ItemStack> harvested, Stack<ItemStack> pendingProduce) {
+    public void stowHarvest(Iterable<ItemStack> harvested, Deque<ItemStack> pendingProduce) {
         for (ItemStack harvest : harvested) {
             if (harvest == null) {
                 continue;
@@ -232,7 +232,7 @@ public class InventoryFarm extends InventoryAdapterRestricted implements IFarmIn
         }
     }
 
-    public boolean tryAddPendingProduce(Stack<ItemStack> pendingProduce) {
+    public boolean tryAddPendingProduce(Deque<ItemStack> pendingProduce) {
         IInventory productInventory = getProductInventory();
 
         ItemStack next = pendingProduce.peek();


### PR DESCRIPTION
~20k alloc/sec -> ~6k alloc/sec

Uses MutableVect where appropriate, and expands IVect - tested in the full pack

Also swaps out Stack (synchronized) for ArrayDeque (unsynchronized) -- I didn't profile this but SonarLint made the suggestion and it seemed reasonable.


Before:
![image](https://github.com/GTNewHorizons/ForestryMC/assets/1894689/3dbd3834-9073-427e-a16c-3b0d083ef764)


After:
![image](https://github.com/GTNewHorizons/ForestryMC/assets/1894689/60423e29-dbbf-4f5a-888a-7329e3fbe9eb)
