### PR TITLE
Add Butterfly Leaf Spawn Config

### DIFF
--- a/src/main/java/forestry/plugins/PluginLepidopterology.java
+++ b/src/main/java/forestry/plugins/PluginLepidopterology.java
@@ -60,6 +60,7 @@ public class PluginLepidopterology extends ForestryPlugin {
     public static int spawnConstraint = 100;
     public static int entityConstraint = 1000;
     private static boolean allowPollination = true;
+    public static boolean disableButterflyLeafSpawns = false;
 
     public static ItemRegistryLepidopterology items;
     public static BlockRegistryLepidopterology blocks;
@@ -112,7 +113,8 @@ public class PluginLepidopterology extends ForestryPlugin {
 
         blocks.lepidopterology.init();
 
-        TreeManager.treeRoot.registerLeafTickHandler(new ButterflySpawner());
+        if (!PluginLepidopterology.disableButterflyLeafSpawns)
+            TreeManager.treeRoot.registerLeafTickHandler(new ButterflySpawner());
 
         RecipeSorter.register(
                 "forestry:lepidopterologymating",
@@ -127,6 +129,8 @@ public class PluginLepidopterology extends ForestryPlugin {
         spawnConstraint = config.getIntLocalized("butterfly.entities", "spawn.limit", spawnConstraint, 0, 500);
         entityConstraint = config.getIntLocalized("butterfly.entities", "maximum", entityConstraint, 0, 5000);
         allowPollination = config.getBooleanLocalized("butterfly.entities", "pollination", allowPollination);
+        disableButterflyLeafSpawns = config
+                .getBooleanLocalized("butterfly.entities", "disable.leaf.spawns", disableButterflyLeafSpawns);
 
         config.save();
     }

--- a/src/main/resources/assets/forestry/lang/en_US.lang
+++ b/src/main/resources/assets/forestry/lang/en_US.lang
@@ -1684,6 +1684,8 @@ for.config.butterfly.entities.maximum=Butterfly Maximum
 for.config.butterfly.entities.maximum.comment=New butterflies will stay in item form and will not take flight once this limit is reached.
 for.config.butterfly.entities.pollination=Butterfly Pollination
 for.config.butterfly.entities.pollination.comment=Allow butterflies to pollinate leaves.
+for.config.butterfly.entities.disable.leaf.spawns=Disable Butterfly Leaf Spawns
+for.config.butterfly.entities.disable.leaf.spawns.comment=Prevent random butterflies from autonomously spawning from Forestry leaves.
 
 for.config.backpacks.item.stacks.format=Add itemStacks for the %s's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
 for.config.backpacks.ore.dict.format=Add ore dictionary names for the %s's backpack here in the format 'oreDictName'.


### PR DESCRIPTION
This is yet another PR regarding butterflies, specifically disabling their natural spawn. Some of you might have already noticed there exists a very similar config already for such cases:

```yaml
mobs {
    # [default: false]
    B:disable.butterfly=false
}
```

However, this is a complete kill-switch, preventing Butterfly entities from generating at all in any world (be it naturally, via item form, or through mating).

What is known by most is that butterflies spawn by the load and create lots of lag as every leaf from Forestry trees will randomly spawn butterflies over time, whether the user intentionally wants it or not.

The problem is exacerbated by the simplicity of automating and populating vast fields of Forestry trees.

That's how you unintentionally create thousands if not hundreds of thousands of valid butterfly generators that require absolutely no upkeep and, worst of all, there is no way for the end-user to mitigate it except adding a hard cap to butterflies to the server.

### What's the goal of these changes?

Most butterflies are generated from users who neither have the intention nor understanding of meddling with such Lepidopterology nor have any realistic long-term solutions to these recurrent squatter cases.

This, however, does not discount the fact that there still exists a minority of gamers who find it an attractive endeavor to do in their free time.

This PR gives the means for developers to provide access to butterflies through other, more responsible methods than the one provided by Forestry.

### Ok, but what's the intended recommendation?

This PR was created with Binnie Mods in mind as a replacement for Forestry's original spawn mechanics.

Binnie offers a Botanical module where its flowers, while placed on valid soil, will begin their life cycle and spawn butterflies like any Forestry leaf would.

These do require some upkeep from the player or else they will wilt and die.
Flower farms are also much harder to automate as the only effective way to do so is by using a Forestry Multifarm.

Even in the most egregious automated flower field, it won't be able to churn out more butterflies than the average tree orchard (~30 butterfly-generating leaves per tree with no upkeep).

#### Butterflies will still pollinate trees, and mated butterflies will still be able to make cocoons on Forestry leaves, so the intended mechanics used by players would remain intact.

Such changes would also ultimately gate butterfly content behind another cosmetic content for these mostly cosmetic creatures, making it even more desirable.

I am confident that implementing these changes will foster greater acceptance of butterflies, shifting away from any negative associations they may have held previously as harbingers of lag.
![image](https://github.com/GTNewHorizons/ForestryMC/assets/47131096/c10a6c30-6dc4-4940-9f8b-540dfc61f208)