### PR TITLE
Bee Mutation Logic Fix

### DIFF
--- a/src/main/java/forestry/apiculture/genetics/BeeMutation.java
+++ b/src/main/java/forestry/apiculture/genetics/BeeMutation.java
@@ -49,8 +49,8 @@ public class BeeMutation extends Mutation implements IBeeMutationCustom {
         IBeeModifier beeHousingModifier = BeeManager.beeRoot.createBeeHousingModifier(housing);
         IBeeModifier beeModeModifier = BeeManager.beeRoot.getBeekeepingMode(world).getBeeModifier();
 
-        processedChance *= beeHousingModifier.getMutationModifier(genome0, genome1, processedChance);
-        processedChance *= beeModeModifier.getMutationModifier(genome0, genome1, processedChance);
+        processedChance *= beeHousingModifier.getMutationModifier(genome0, genome1, 1.0F);
+        processedChance *= beeModeModifier.getMutationModifier(genome0, genome1, 1.0F);
 
         return processedChance;
     }


### PR DESCRIPTION
resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13681

Problem: Mutation modifiers are applied incorrectly for Extrabees frames due to their maximum modifier logic.

Cause: In the initial stage of mutation chance calculation, processedChance is passed for the currentModifier parameter, causing logical error in later part of the calculation specifically in the following code in https://github.com/GTNewHorizons/Binnie/blob/master/src/main/java/binnie/core/genetics/BeeModifierLogic.java

    public float getModifier(EnumBeeModifier modifier, float currentModifier) {
        if (modifier == EnumBeeModifier.PRODUCTION) {
            if (!modifiers.containsKey(modifier)) {
                return 0.0f;
            }
            Float[] values = modifiers.get(modifier);
            float offset = values[0], max = values[1];
            if (offset < 0) {// negative modifiers should always apply
                return offset;
            }
            if (currentModifier >= max) {// don't decrease modifiers already over the max, just skip increasing it
                return 0.0f;
            }
            return Math.min(offset, max - currentModifier);
        } else {
            if (!modifiers.containsKey(modifier)) {
                return 1.0f;
            }


            Float[] values = modifiers.get(modifier);
            float mult = values[0];
            float max = values[1];
            if (max >= 1.0f) {
                if (max <= currentModifier) {
                    return 1.0f;
                }
                return Math.min(max / currentModifier, mult);
            }


            if (max >= currentModifier) {
                return 1.0f;
            }
            return Math.max(max / currentModifier, mult);
        }


    }


Solution: pass 1.0F instead of processedChance for the currentModifier parmeter.