### PR TITLE
Remove duplicate items

### DIFF
--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -15,6 +15,7 @@ import net.minecraft.item.Item;
 import net.minecraftforge.common.MinecraftForge;
 
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.ModAPIManager;
@@ -79,10 +80,14 @@ public class Forestry {
 
     public static PacketHandler packetHandler;
 
+    public static boolean isDreamcraftLoaded;
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
         checkForCoFHLib();
         packetHandler = new PacketHandler();
+
+        isDreamcraftLoaded = Loader.isModLoaded("dreamcraft");
 
         // Register event handler
         EventHandlerCore eventHandlerCore = new EventHandlerCore();

--- a/src/main/java/forestry/core/items/ItemRegistryCore.java
+++ b/src/main/java/forestry/core/items/ItemRegistryCore.java
@@ -8,6 +8,8 @@
  ******************************************************************************/
 package forestry.core.items;
 
+import static forestry.Forestry.isDreamcraftLoaded;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -87,19 +89,26 @@ public class ItemRegistryCore extends ItemRegistry {
         fertilizerBio = registerItem(new ItemForestry(), "fertilizerBio");
         fertilizerCompound = registerItem(new ItemForestryBonemeal(), "fertilizerCompound");
 
-        apatite = registerItem(new ItemForestry(), "apatite");
-        OreDictionary.registerOre("gemApatite", apatite);
-
         researchNote = registerItem(new ItemResearchNote(), "researchNote");
 
-        ingotCopper = registerItem(new ItemForestry(), "ingotCopper");
-        OreDictionary.registerOre("ingotCopper", ingotCopper);
+        if(!isDreamcraftLoaded) {
+            apatite = registerItem(new ItemForestry(), "apatite");
+            OreDictionary.registerOre("gemApatite", apatite);
 
-        ingotTin = registerItem(new ItemForestry(), "ingotTin");
-        OreDictionary.registerOre("ingotTin", ingotTin);
+            ingotCopper = registerItem(new ItemForestry(), "ingotCopper");
+            OreDictionary.registerOre("ingotCopper", ingotCopper);
 
-        ingotBronze = registerItem(new ItemForestry(), "ingotBronze");
-        OreDictionary.registerOre("ingotBronze", ingotBronze);
+            ingotTin = registerItem(new ItemForestry(), "ingotTin");
+            OreDictionary.registerOre("ingotTin", ingotTin);
+
+            ingotBronze = registerItem(new ItemForestry(), "ingotBronze");
+            OreDictionary.registerOre("ingotBronze", ingotBronze);
+        }else{
+            apatite=null;
+            ingotCopper=null;
+            ingotTin=null;
+            ingotBronze=null;
+        }
 
         wrench = registerItem(new ItemWrench(), "wrench");
         pipette = registerItem(new ItemPipette(), "pipette");

--- a/src/main/java/forestry/core/items/ItemRegistryCore.java
+++ b/src/main/java/forestry/core/items/ItemRegistryCore.java
@@ -91,7 +91,7 @@ public class ItemRegistryCore extends ItemRegistry {
 
         researchNote = registerItem(new ItemResearchNote(), "researchNote");
 
-        if(!isDreamcraftLoaded) {
+        if (!isDreamcraftLoaded) {
             apatite = registerItem(new ItemForestry(), "apatite");
             OreDictionary.registerOre("gemApatite", apatite);
 
@@ -103,11 +103,11 @@ public class ItemRegistryCore extends ItemRegistry {
 
             ingotBronze = registerItem(new ItemForestry(), "ingotBronze");
             OreDictionary.registerOre("ingotBronze", ingotBronze);
-        }else{
-            apatite=null;
-            ingotCopper=null;
-            ingotTin=null;
-            ingotBronze=null;
+        } else {
+            apatite = null;
+            ingotCopper = null;
+            ingotTin = null;
+            ingotBronze = null;
         }
 
         wrench = registerItem(new ItemWrench(), "wrench");

--- a/src/main/java/forestry/plugins/PluginCore.java
+++ b/src/main/java/forestry/plugins/PluginCore.java
@@ -8,6 +8,8 @@
  ******************************************************************************/
 package forestry.plugins;
 
+import static forestry.Forestry.isDreamcraftLoaded;
+
 import java.util.ArrayList;
 
 import net.minecraft.command.ICommand;
@@ -132,14 +134,16 @@ public class PluginCore extends ForestryPlugin {
 
         // forestry items
         crateRegistry.registerCrate(items.peat, "cratedPeat");
-        crateRegistry.registerCrate(items.apatite, "cratedApatite");
         crateRegistry.registerCrate(items.fertilizerCompound, "cratedFertilizer");
         crateRegistry.registerCrate(items.mulch, "cratedMulch");
         crateRegistry.registerCrate(items.phosphor, "cratedPhosphor");
         crateRegistry.registerCrate(items.ash, "cratedAsh");
-        crateRegistry.registerCrateUsingOreDict(items.ingotTin, "cratedTin");
-        crateRegistry.registerCrateUsingOreDict(items.ingotCopper, "cratedCopper");
-        crateRegistry.registerCrateUsingOreDict(items.ingotBronze, "cratedBronze");
+        if(!isDreamcraftLoaded) {
+            crateRegistry.registerCrate(items.apatite, "cratedApatite");
+            crateRegistry.registerCrateUsingOreDict(items.ingotTin, "cratedTin");
+            crateRegistry.registerCrateUsingOreDict(items.ingotCopper, "cratedCopper");
+            crateRegistry.registerCrateUsingOreDict(items.ingotBronze, "cratedBronze");
+        }
 
         // forestry blocks
         crateRegistry.registerCrate(blocks.soil.get(BlockSoil.SoilType.HUMUS, 1), "cratedHumus");
@@ -195,9 +199,11 @@ public class PluginCore extends ForestryPlugin {
     protected void registerRecipes() {
 
         /* SMELTING RECIPES */
-        RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.APATITE, 1), items.apatite, 0.5f);
-        RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.COPPER, 1), items.ingotCopper, 0.5f);
-        RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.TIN, 1), items.ingotTin, 0.5f);
+        if(!isDreamcraftLoaded) {
+            RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.APATITE, 1), items.apatite, 0.5f);
+            RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.COPPER, 1), items.ingotCopper, 0.5f);
+            RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.TIN, 1), items.ingotTin, 0.5f);
+        }
         RecipeUtil.addSmelting(new ItemStack(items.peat), items.ash, 0.0f);
 
         /* BRONZE INGOTS */
@@ -382,41 +388,43 @@ public class PluginCore extends ForestryPlugin {
                 new ItemStack(Blocks.wool, 1, OreDictionary.WILDCARD_VALUE));
 
         // Storage Blocks
-        RecipeUtil.addRecipe(
-                blocks.resourceStorage.get(BlockResourceStorage.ResourceType.APATITE),
-                "###",
-                "###",
-                "###",
-                '#',
-                "gemApatite");
-        RecipeUtil.addShapelessRecipe(new ItemStack(items.apatite, 9), "blockApatite");
+        if(!isDreamcraftLoaded) {
+            RecipeUtil.addRecipe(
+                    blocks.resourceStorage.get(BlockResourceStorage.ResourceType.APATITE),
+                    "###",
+                    "###",
+                    "###",
+                    '#',
+                    "gemApatite");
+            RecipeUtil.addShapelessRecipe(new ItemStack(items.apatite, 9), "blockApatite");
 
-        RecipeUtil.addRecipe(
-                blocks.resourceStorage.get(BlockResourceStorage.ResourceType.COPPER),
-                "###",
-                "###",
-                "###",
-                '#',
-                "ingotCopper");
-        RecipeUtil.addShapelessRecipe(new ItemStack(items.ingotCopper, 9), "blockCopper");
+            RecipeUtil.addRecipe(
+                    blocks.resourceStorage.get(BlockResourceStorage.ResourceType.COPPER),
+                    "###",
+                    "###",
+                    "###",
+                    '#',
+                    "ingotCopper");
+            RecipeUtil.addShapelessRecipe(new ItemStack(items.ingotCopper, 9), "blockCopper");
 
-        RecipeUtil.addRecipe(
-                blocks.resourceStorage.get(BlockResourceStorage.ResourceType.TIN),
-                "###",
-                "###",
-                "###",
-                '#',
-                "ingotTin");
-        RecipeUtil.addShapelessRecipe(new ItemStack(items.ingotTin, 9), "blockTin");
+            RecipeUtil.addRecipe(
+                    blocks.resourceStorage.get(BlockResourceStorage.ResourceType.TIN),
+                    "###",
+                    "###",
+                    "###",
+                    '#',
+                    "ingotTin");
+            RecipeUtil.addShapelessRecipe(new ItemStack(items.ingotTin, 9), "blockTin");
 
-        RecipeUtil.addRecipe(
-                blocks.resourceStorage.get(BlockResourceStorage.ResourceType.BRONZE),
-                "###",
-                "###",
-                "###",
-                '#',
-                "ingotBronze");
-        RecipeUtil.addShapelessRecipe(new ItemStack(items.ingotBronze, 9), "blockBronze");
+            RecipeUtil.addRecipe(
+                    blocks.resourceStorage.get(BlockResourceStorage.ResourceType.BRONZE),
+                    "###",
+                    "###",
+                    "###",
+                    '#',
+                    "ingotBronze");
+            RecipeUtil.addShapelessRecipe(new ItemStack(items.ingotBronze, 9), "blockBronze");
+        }
     }
 
     @Override

--- a/src/main/java/forestry/plugins/PluginCore.java
+++ b/src/main/java/forestry/plugins/PluginCore.java
@@ -138,7 +138,7 @@ public class PluginCore extends ForestryPlugin {
         crateRegistry.registerCrate(items.mulch, "cratedMulch");
         crateRegistry.registerCrate(items.phosphor, "cratedPhosphor");
         crateRegistry.registerCrate(items.ash, "cratedAsh");
-        if(!isDreamcraftLoaded) {
+        if (!isDreamcraftLoaded) {
             crateRegistry.registerCrate(items.apatite, "cratedApatite");
             crateRegistry.registerCrateUsingOreDict(items.ingotTin, "cratedTin");
             crateRegistry.registerCrateUsingOreDict(items.ingotCopper, "cratedCopper");
@@ -199,9 +199,12 @@ public class PluginCore extends ForestryPlugin {
     protected void registerRecipes() {
 
         /* SMELTING RECIPES */
-        if(!isDreamcraftLoaded) {
+        if (!isDreamcraftLoaded) {
             RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.APATITE, 1), items.apatite, 0.5f);
-            RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.COPPER, 1), items.ingotCopper, 0.5f);
+            RecipeUtil.addSmelting(
+                    blocks.resources.get(BlockResourceOre.ResourceType.COPPER, 1),
+                    items.ingotCopper,
+                    0.5f);
             RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.TIN, 1), items.ingotTin, 0.5f);
         }
         RecipeUtil.addSmelting(new ItemStack(items.peat), items.ash, 0.0f);
@@ -388,7 +391,7 @@ public class PluginCore extends ForestryPlugin {
                 new ItemStack(Blocks.wool, 1, OreDictionary.WILDCARD_VALUE));
 
         // Storage Blocks
-        if(!isDreamcraftLoaded) {
+        if (!isDreamcraftLoaded) {
             RecipeUtil.addRecipe(
                     blocks.resourceStorage.get(BlockResourceStorage.ResourceType.APATITE),
                     "###",

--- a/src/main/java/forestry/plugins/PluginFactory.java
+++ b/src/main/java/forestry/plugins/PluginFactory.java
@@ -8,6 +8,8 @@
  ******************************************************************************/
 package forestry.plugins;
 
+import static forestry.Forestry.isDreamcraftLoaded;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -644,18 +646,20 @@ public class PluginFactory extends ForestryPlugin {
                 new Object[] { " # ", " X ", " X ", '#', "ingotBronze", 'X', "stickWood" });
 
         // Reclamation
-        RecipeManagers.carpenterManager.addRecipe(
-                null,
-                PluginCore.items.ingotBronze.getItemStack(2),
-                "#",
-                '#',
-                PluginCore.items.brokenBronzePickaxe);
-        RecipeManagers.carpenterManager.addRecipe(
-                null,
-                PluginCore.items.ingotBronze.getItemStack(),
-                "#",
-                '#',
-                PluginCore.items.brokenBronzeShovel);
+        if(!isDreamcraftLoaded) {
+            RecipeManagers.carpenterManager.addRecipe(
+                    null,
+                    PluginCore.items.ingotBronze.getItemStack(2),
+                    "#",
+                    '#',
+                    PluginCore.items.brokenBronzePickaxe);
+            RecipeManagers.carpenterManager.addRecipe(
+                    null,
+                    PluginCore.items.ingotBronze.getItemStack(),
+                    "#",
+                    '#',
+                    PluginCore.items.brokenBronzeShovel);
+        }
 
         // Crating and uncrating
         if (PluginManager.Module.STORAGE.isEnabled()) {

--- a/src/main/java/forestry/plugins/PluginFactory.java
+++ b/src/main/java/forestry/plugins/PluginFactory.java
@@ -646,7 +646,7 @@ public class PluginFactory extends ForestryPlugin {
                 new Object[] { " # ", " X ", " X ", '#', "ingotBronze", 'X', "stickWood" });
 
         // Reclamation
-        if(!isDreamcraftLoaded) {
+        if (!isDreamcraftLoaded) {
             RecipeManagers.carpenterManager.addRecipe(
                     null,
                     PluginCore.items.ingotBronze.getItemStack(2),

--- a/src/main/java/forestry/plugins/PluginFluids.java
+++ b/src/main/java/forestry/plugins/PluginFluids.java
@@ -132,7 +132,7 @@ public class PluginFluids extends ForestryPlugin {
         }
 
         if (RecipeManagers.squeezerManager != null) {
-            if(!isDreamcraftLoaded) {
+            if (!isDreamcraftLoaded) {
                 RecipeManagers.squeezerManager.addContainerRecipe(
                         10,
                         items.canEmpty.getItemStack(),

--- a/src/main/java/forestry/plugins/PluginFluids.java
+++ b/src/main/java/forestry/plugins/PluginFluids.java
@@ -8,6 +8,8 @@
  ******************************************************************************/
 package forestry.plugins;
 
+import static forestry.Forestry.isDreamcraftLoaded;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -130,11 +132,13 @@ public class PluginFluids extends ForestryPlugin {
         }
 
         if (RecipeManagers.squeezerManager != null) {
-            RecipeManagers.squeezerManager.addContainerRecipe(
-                    10,
-                    items.canEmpty.getItemStack(),
-                    PluginCore.items.ingotTin.getItemStack(),
-                    0.05f);
+            if(!isDreamcraftLoaded) {
+                RecipeManagers.squeezerManager.addContainerRecipe(
+                        10,
+                        items.canEmpty.getItemStack(),
+                        PluginCore.items.ingotTin.getItemStack(),
+                        0.05f);
+            }
             RecipeManagers.squeezerManager.addContainerRecipe(
                     10,
                     items.waxCapsuleEmpty.getItemStack(),


### PR DESCRIPTION
never registers: copper ingot, bronze ingot, tin ingot, apatite gem, and corresponding forestry crates if GTNH is detected.

Also removes some recipe collisions.

requires https://github.com/GTNewHorizons/MagicBees/pull/48