### PR TITLE
fix: Use GT ash instead of letting unification screw everything up.

### DIFF
--- a/src/main/java/forestry/apiculture/genetics/BeeDefinition.java
+++ b/src/main/java/forestry/apiculture/genetics/BeeDefinition.java
@@ -331,7 +331,7 @@ public enum BeeDefinition implements IBeeDefinition {
         @Override
         protected void setSpeciesProperties(IAlleleBeeSpeciesCustom beeSpecies) {
             beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.SIMMERING, 1), 0.55f)
-                    .addProduct(PluginCore.items.ash.getItemStack(), 0.15f).setTemperature(EnumTemperature.HELLISH)
+                    .addProduct(PluginCore.items.getAsh(), 0.15f).setTemperature(EnumTemperature.HELLISH)
                     .setHumidity(EnumHumidity.ARID);
         }
 

--- a/src/main/java/forestry/core/items/ItemRegistryCore.java
+++ b/src/main/java/forestry/core/items/ItemRegistryCore.java
@@ -10,6 +10,8 @@ package forestry.core.items;
 
 import static forestry.Forestry.isDreamcraftLoaded;
 
+import java.util.List;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -65,7 +67,7 @@ public class ItemRegistryCore extends ItemRegistry {
 
     /* Peat */
     public final ItemForestry peat;
-    public final ItemForestry ash;
+    private final ItemForestry ash;
     public final ItemForestry bituminousPeat;
 
     /* Moistener */
@@ -195,5 +197,13 @@ public class ItemRegistryCore extends ItemRegistry {
             ItemStack fruit = new ItemStack(fruits, 1, def.ordinal());
             OreDictionary.registerOre(def.getOreDict(), fruit);
         }
+    }
+
+    public ItemStack getAsh() {
+        List<ItemStack> options = OreDictionary.getOres("dustAsh");
+        for (ItemStack option : options) {
+            if (option.getItem() != ash) return option.copy();
+        }
+        return ash.getItemStack();
     }
 }

--- a/src/main/java/forestry/energy/tiles/TileEnginePeat.java
+++ b/src/main/java/forestry/energy/tiles/TileEnginePeat.java
@@ -78,7 +78,7 @@ public class TileEnginePeat extends TileEngine implements ISidedInventory {
                 return i;
             }
 
-            if (waste.getItem() != PluginCore.items.ash) {
+            if (waste.getItem() != PluginCore.items.getAsh().getItem()) {
                 continue;
             }
 
@@ -182,7 +182,7 @@ public class TileEnginePeat extends TileEngine implements ISidedInventory {
         if (wasteSlot >= 0) {
             IInventoryAdapter inventory = getInternalInventory();
             if (inventory.getStackInSlot(wasteSlot) == null) {
-                inventory.setInventorySlotContents(wasteSlot, PluginCore.items.ash.getItemStack());
+                inventory.setInventorySlotContents(wasteSlot, PluginCore.items.getAsh());
             } else {
                 inventory.getStackInSlot(wasteSlot).stackSize++;
             }

--- a/src/main/java/forestry/plugins/PluginCore.java
+++ b/src/main/java/forestry/plugins/PluginCore.java
@@ -137,7 +137,7 @@ public class PluginCore extends ForestryPlugin {
         crateRegistry.registerCrate(items.fertilizerCompound, "cratedFertilizer");
         crateRegistry.registerCrate(items.mulch, "cratedMulch");
         crateRegistry.registerCrate(items.phosphor, "cratedPhosphor");
-        crateRegistry.registerCrate(items.ash, "cratedAsh");
+        crateRegistry.registerCrateUsingOreDict(items.getAsh(), "cratedAsh");
         if (!isDreamcraftLoaded) {
             crateRegistry.registerCrate(items.apatite, "cratedApatite");
             crateRegistry.registerCrateUsingOreDict(items.ingotTin, "cratedTin");
@@ -207,7 +207,7 @@ public class PluginCore extends ForestryPlugin {
                     0.5f);
             RecipeUtil.addSmelting(blocks.resources.get(BlockResourceOre.ResourceType.TIN, 1), items.ingotTin, 0.5f);
         }
-        RecipeUtil.addSmelting(new ItemStack(items.peat), items.ash, 0.0f);
+        RecipeUtil.addSmelting(new ItemStack(items.peat), items.getAsh(), 0.0f);
 
         /* BRONZE INGOTS */
         if (Config.isCraftingBronzeEnabled()) {

--- a/src/main/java/forestry/plugins/PluginStorage.java
+++ b/src/main/java/forestry/plugins/PluginStorage.java
@@ -449,10 +449,15 @@ public class PluginStorage extends ForestryPlugin {
                     String oreName = OreDictionary.getOreName(oreId);
                     addCrating(crateStack, oreName);
                 }
+                if (oreIds.length > 0 && oreIds[0] == OreDictionary.getOreID("dustAsh")) {
+                    addUncrating(crateStack, PluginCore.items.getAsh());
+                } else {
+                    addUncrating(crateStack, uncrated);
+                }
             } else {
                 addCrating(crateStack, uncrated);
+                addUncrating(crateStack, uncrated);
             }
-            addUncrating(crateStack, uncrated);
         }
     }
 


### PR DESCRIPTION
This prevents the generation of forestry ash if another variant is available.

- Fiendish bees output GT ash
- Peat engines produce GT ash
- Peat can be smelted into GT ash
- Ash crates use oredict for packaging recipe (i.e. forestry or GT ash)
- Uncrating ash crates produces GT ash.

This should resolve https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17056