### PR TITLE
Don't crash if someone tries to color number values stored in lang files

### DIFF
--- a/src/main/java/forestry/core/tiles/EscritoireTextSource.java
+++ b/src/main/java/forestry/core/tiles/EscritoireTextSource.java
@@ -37,7 +37,8 @@ public class EscritoireTextSource {
         EnumSet<Notes> multipleTranslationNoteLevels = EnumSet
                 .of(Notes.level1, Notes.level2, Notes.level3, Notes.level4, Notes.success, Notes.failure);
         for (Notes notesLevel : multipleTranslationNoteLevels) {
-            int levelCount = Integer.valueOf(StringUtil.localize("gui.escritoire.notes." + notesLevel + ".count"));
+            int levelCount = Integer.valueOf(
+                    StringUtil.localize("gui.escritoire.notes." + notesLevel + ".count").replaceAll("§\\d", ""));
             for (int i = 1; i <= levelCount; i++) {
                 String note = StringUtil.localize("gui.escritoire.notes." + notesLevel + '.' + i);
                 researchNotes.put(notesLevel, note);


### PR DESCRIPTION
One of the dumbest issues I've ever seen, both because we probably shouldn't parse numbers from lang files and because people shouldn't expect messing with lang keys at random to always give good results.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17032

To clarify, the lang entry is a number like `3` but something is overriding it by trying to make it gray so the translation result is `§73` instead.