### PR TITLE
Fix multiblock components to drop inventory contents when broken

### DIFF
--- a/src/main/java/forestry/api/multiblock/IMultiblockComponent.java
+++ b/src/main/java/forestry/api/multiblock/IMultiblockComponent.java
@@ -9,6 +9,8 @@ import net.minecraft.util.ChunkCoordinates;
 
 import com.mojang.authlib.GameProfile;
 
+import forestry.core.inventory.IInventoryAdapter;
+
 /**
  * Basic interface for a multiblock machine component. Implemented by TileEntities.
  */
@@ -45,4 +47,15 @@ public interface IMultiblockComponent {
      * Called when the machine is broken for game reasons, e.g. a player removed a block or an explosion occurred.
      */
     void onMachineBroken();
+
+    /**
+     * A component with a separate inventory, like the Alveary Swarmer or Alveary Sieve.
+     */
+    interface HasInventory {
+
+        /**
+         * Called when this part is destroyed to drop its contents.
+         */
+        IInventoryAdapter getInternalInventory();
+    }
 }

--- a/src/main/java/forestry/apiculture/multiblock/TileAlvearyHygroregulator.java
+++ b/src/main/java/forestry/apiculture/multiblock/TileAlvearyHygroregulator.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import forestry.api.core.IClimateControlled;
 import forestry.api.multiblock.IAlvearyComponent;
+import forestry.api.multiblock.IMultiblockComponent;
 import forestry.apiculture.blocks.BlockAlveary;
 import forestry.apiculture.gui.ContainerAlvearyHygroregulator;
 import forestry.apiculture.gui.GuiAlvearyHygroregulator;
@@ -31,8 +32,8 @@ import forestry.core.fluids.tanks.FilteredTank;
 import forestry.core.inventory.IInventoryAdapter;
 import forestry.core.tiles.ILiquidTankTile;
 
-public class TileAlvearyHygroregulator extends TileAlveary
-        implements IInventory, ILiquidTankTile, IFluidHandler, IAlvearyComponent.Climatiser {
+public class TileAlvearyHygroregulator extends TileAlveary implements IInventory, ILiquidTankTile, IFluidHandler,
+        IAlvearyComponent.Climatiser, IMultiblockComponent.HasInventory {
 
     private final HygroregulatorRecipe[] recipes;
 

--- a/src/main/java/forestry/apiculture/multiblock/TileAlvearySieve.java
+++ b/src/main/java/forestry/apiculture/multiblock/TileAlvearySieve.java
@@ -18,6 +18,7 @@ import forestry.api.genetics.AlleleManager;
 import forestry.api.genetics.IIndividual;
 import forestry.api.genetics.ISpeciesRoot;
 import forestry.api.multiblock.IAlvearyComponent;
+import forestry.api.multiblock.IMultiblockComponent;
 import forestry.apiculture.blocks.BlockAlveary;
 import forestry.apiculture.gui.ContainerAlvearySieve;
 import forestry.apiculture.gui.GuiAlvearySieve;
@@ -25,7 +26,8 @@ import forestry.apiculture.inventory.InventoryAlvearySieve;
 import forestry.core.inventory.IInventoryAdapter;
 import forestry.core.inventory.watchers.ISlotPickupWatcher;
 
-public class TileAlvearySieve extends TileAlveary implements IAlvearyComponent.BeeListener {
+public class TileAlvearySieve extends TileAlveary
+        implements IAlvearyComponent.BeeListener, IMultiblockComponent.HasInventory {
 
     private final IBeeListener beeListener;
     private final InventoryAlvearySieve inventory;

--- a/src/main/java/forestry/apiculture/multiblock/TileAlvearySwarmer.java
+++ b/src/main/java/forestry/apiculture/multiblock/TileAlvearySwarmer.java
@@ -22,6 +22,7 @@ import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.EnumBeeType;
 import forestry.api.apiculture.IBee;
 import forestry.api.multiblock.IAlvearyComponent;
+import forestry.api.multiblock.IMultiblockComponent;
 import forestry.apiculture.blocks.BlockAlveary;
 import forestry.apiculture.gui.ContainerAlvearySwarmer;
 import forestry.apiculture.gui.GuiAlvearySwarmer;
@@ -37,7 +38,8 @@ import forestry.core.proxy.Proxies;
 import forestry.core.tiles.IActivatable;
 import forestry.core.utils.ItemStackUtil;
 
-public class TileAlvearySwarmer extends TileAlveary implements ISidedInventory, IActivatable, IAlvearyComponent.Active {
+public class TileAlvearySwarmer extends TileAlveary
+        implements ISidedInventory, IActivatable, IAlvearyComponent.Active, IMultiblockComponent.HasInventory {
 
     private final InventorySwarmer inventory;
     private final Deque<ItemStack> pendingSpawns = new ArrayDeque<>();

--- a/src/main/java/forestry/core/blocks/BlockStructure.java
+++ b/src/main/java/forestry/core/blocks/BlockStructure.java
@@ -116,6 +116,12 @@ public abstract class BlockStructure extends BlockForestry {
                     InventoryUtil.dropSockets((ISocketable) tile, world, x, y, z);
                 }
             }
+
+            if (tile instanceof IMultiblockComponent.HasInventory) {
+                IMultiblockComponent.HasInventory hasInventory = (IMultiblockComponent.HasInventory) tile;
+
+                InventoryUtil.dropInventory(hasInventory.getInternalInventory(), world, x, y, z);
+            }
         }
         super.breakBlock(world, x, y, z, block, meta);
     }


### PR DESCRIPTION
Backports the fix for https://github.com/thedarkcolour/ForestryCE/issues/207 to 1.7.10, which is a bug where Alveary blocks with separate inventories such as the Alveary Sieve do not drop their inventories when destroyed.

Adds an interface, `IMultiblockComponent.HasInventory`, which can be implemented on `IMultiblockComponent` to tell `BlockStructure` that it has a separate inventory from the rest of the multiblock (ex. the slot for Woven Silk on the Alveary Sieve) that should be dropped when the block is broken.

I found this because I was curious about whether the bug was a regression in my 1.20.1 version of Forestry, but found that the 1.7.10 also suffered from this bug.

Addon mods such as Binnie's might also need fixing, separately from this PR.