### PR TITLE
Added color localization for the missing items inside the worktable gui

### DIFF
--- a/src/main/java/forestry/factory/gui/GuiWorktable.java
+++ b/src/main/java/forestry/factory/gui/GuiWorktable.java
@@ -118,7 +118,7 @@ public class GuiWorktable extends GuiForestryTitled<ContainerWorktable, TileWork
 
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glTranslatef(0, 0, 150);
-        drawRect(left, top, left + 16, top + 16, 0x88ff0000);
+        drawRect(left, top, left + 16, top + 16, 0x88000000 | getFontColor().get("gui.worktable.missing"));
         GL11.glTranslatef(0, 0, -150);
         GL11.glEnable(GL11.GL_LIGHTING);
     }

--- a/src/main/resources/assets/forestry/config/colour.properties
+++ b/src/main/resources/assets/forestry/config/colour.properties
@@ -10,6 +10,7 @@ gui.screen=ffffff
 gui.table.header=ababab
 gui.table.row=ababab
 gui.book=000000
+gui.worktable.missing=ff0000
 
 gui.beealyzer.binomial=14d50b
 gui.beealyzer.recessive=3687ec


### PR DESCRIPTION
Because I hate it and want to change it with resource pack

<img width="326" height="236" alt="image" src="https://github.com/user-attachments/assets/dca8e08b-b17f-4ff7-ab29-d31247f37d95" />

In-game without a change