### PR TITLE
change an integer to a float in a division to avoid possible rounding error in apiary comb production formula

### DIFF
--- a/src/main/java/forestry/apiculture/genetics/Bee.java
+++ b/src/main/java/forestry/apiculture/genetics/Bee.java
@@ -573,7 +573,7 @@ public class Bee extends IndividualLiving implements IBee {
         }
         // / Secondary Products
         for (Map.Entry<ItemStack, Float> entry : secondary.getProductChances().entrySet()) {
-            if (housing.getWorld().rand.nextFloat() < getFinalChance(entry.getValue() / 2, speed, prodModifier, 1f)) {
+            if (housing.getWorld().rand.nextFloat() < getFinalChance(entry.getValue() / 2f, speed, prodModifier, 1f)) {
                 products.add(entry.getKey().copy());
             }
         }


### PR DESCRIPTION
Change an integer to a float in a division to avoid possible rounding error in apiary comb production formula in relation to : 
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24462

Its done similarly for industrial apiary in 
https://github.com/GTNewHorizons/GT5-Unofficial/blob/f663bd13681924d28d34569aa28f3d1791f5ada4/src/main/java/gregtech/common/tileentities/machines/basic/MTEIndustrialApiary.java#L344
and for the mega apiary in 
https://github.com/GTNewHorizons/GT5-Unofficial/blob/f663bd13681924d28d34569aa28f3d1791f5ada4/src/main/java/kubatech/tileentity/gregtech/multiblock/MTEMegaIndustrialApiary.java#L1181