### PR TITLE
Add OreDictionary entry for fertile tree pollen

### DIFF
--- a/src/main/java/forestry/arboriculture/items/ItemRegistryArboriculture.java
+++ b/src/main/java/forestry/arboriculture/items/ItemRegistryArboriculture.java
@@ -26,6 +26,7 @@ public class ItemRegistryArboriculture extends ItemRegistry {
         OreDictionary.registerOre("treeSapling", sapling.getWildcard());
 
         pollenFertile = registerItem(new ItemGermlingGE(EnumGermlingType.POLLEN), "pollenFertile");
+        OreDictionary.registerOre("itemPollenFertile", pollenFertile.getWildcard());
         treealyzer = registerItem(new ItemTreealyzer(), "treealyzer");
         grafter = registerItem(new ItemGrafter(4), "grafter");
         grafterProven = registerItem(new ItemGrafter(149), "grafterProven");


### PR DESCRIPTION
## Summary
- Registers `pollenFertile` item under `"itemPollenFertile"` OreDict entry
- Since all tree pollen variants share the same item and differ only by NBT, a single wildcard registration covers all species (Apple, Oak, etc.)
- Allows AE2 patterns to use any tree pollen interchangeably as a crafting ingredient

<img width="543" height="448" alt="image" src="https://github.com/user-attachments/assets/d0704b74-c62d-494d-9e32-f0806d6dbd27" />

<img width="584" height="434" alt="image" src="https://github.com/user-attachments/assets/6e3e5fc2-3ddb-4065-b29d-c3f7d706793c" />

<img width="450" height="411" alt="image" src="https://github.com/user-attachments/assets/5ceb562b-43a5-4b28-8c1c-37ee97fff7ab" />

