### PR TITLE
Add NEI overlays for the carpenter and fabricator

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.9.54:dev")
     api('curse.maven:cofh-lib-220333:2388748')
     compileOnlyApi('com.github.GTNewHorizons:Angelica:2.1.19:api')
-    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev')
+    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.104-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.7.1:api')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.57:api')
     compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')

--- a/src/main/java/forestry/core/network/PacketIdServer.java
+++ b/src/main/java/forestry/core/network/PacketIdServer.java
@@ -28,7 +28,7 @@ public enum PacketIdServer implements IPacketId {
     BEE_LOGIC_ACTIVE_ENTITY_REQUEST,
 
     // Factory
-    WORKTABLE_NEI_SELECT,
+    NEI_SELECT,
 
     // Mail
     LETTER_INFO_REQUEST,

--- a/src/main/java/forestry/core/recipes/nei/CustomOverlayHandler.java
+++ b/src/main/java/forestry/core/recipes/nei/CustomOverlayHandler.java
@@ -23,7 +23,7 @@ import codechicken.nei.api.IOverlayHandler;
 import codechicken.nei.api.IStackPositioner;
 import codechicken.nei.recipe.IRecipeHandler;
 import forestry.core.proxy.Proxies;
-import forestry.factory.network.packets.PacketWorktableNEISelect;
+import forestry.factory.network.packets.PacketNEISelect;
 
 /**
  * @author bdew
@@ -42,7 +42,18 @@ public class CustomOverlayHandler implements IOverlayHandler {
 
     @Override
     public void overlayRecipe(GuiContainer cont, IRecipeHandler recipe, int recipeIndex, boolean shift) {
-        List<PositionedStack> ingr = recipe.getIngredientStacks(recipeIndex);
+        int offsetX = 25;
+        int offsetY = 6;
+        int gridSpacing = 18;
+        List<PositionedStack> ingr;
+        if (recipe instanceof IGridRecipeHandler gridHandler) {
+            offsetX = gridHandler.getGridStartX();
+            offsetY = gridHandler.getGridStartY();
+            gridSpacing = gridHandler.getGridSpacing();
+            ingr = gridHandler.getGridStacks(recipeIndex);
+        } else {
+            ingr = recipe.getIngredientStacks(recipeIndex);
+        }
 
         if (shift || forceShift) {
             NBTTagList stacksnbt = new NBTTagList();
@@ -50,8 +61,8 @@ public class CustomOverlayHandler implements IOverlayHandler {
             for (PositionedStack pstack : ingr) {
                 if (pstack != null) {
                     // This is back-asswards but i don't see a better way :(
-                    int x = (pstack.relx - 25) / 18;
-                    int y = (pstack.rely - 6) / 18;
+                    int x = (pstack.relx - offsetX) / gridSpacing;
+                    int y = (pstack.rely - offsetY) / gridSpacing;
 
                     ItemStack stack = pstack.item;
                     NBTTagCompound stacknbt = stack.writeToNBT(new NBTTagCompound());
@@ -68,7 +79,7 @@ public class CustomOverlayHandler implements IOverlayHandler {
             NBTTagCompound data = new NBTTagCompound();
             data.setTag("stacks", stacksnbt);
 
-            Proxies.net.sendToServer(new PacketWorktableNEISelect(data));
+            Proxies.net.sendToServer(new PacketNEISelect(data));
         } else {
             IStackPositioner positioner = new OffsetPositioner(xOffs, yOffs);
             LayoutManager.overlayRenderer = new DefaultOverlayRenderer(ingr, positioner);

--- a/src/main/java/forestry/core/recipes/nei/IGridRecipeHandler.java
+++ b/src/main/java/forestry/core/recipes/nei/IGridRecipeHandler.java
@@ -1,0 +1,17 @@
+package forestry.core.recipes.nei;
+
+import java.util.List;
+
+import codechicken.nei.PositionedStack;
+
+public interface IGridRecipeHandler {
+
+    int getGridStartX();
+
+    int getGridStartY();
+
+    int getGridSpacing();
+
+    List<PositionedStack> getGridStacks(int recipeIndex);
+
+}

--- a/src/main/java/forestry/core/recipes/nei/NEIIntegrationConfig.java
+++ b/src/main/java/forestry/core/recipes/nei/NEIIntegrationConfig.java
@@ -19,6 +19,8 @@ import forestry.api.arboriculture.TreeManager;
 import forestry.api.lepidopterology.ButterflyManager;
 import forestry.api.lepidopterology.EnumFlutterType;
 import forestry.core.utils.Log;
+import forestry.factory.gui.GuiCarpenter;
+import forestry.factory.gui.GuiFabricator;
 import forestry.factory.gui.GuiWorktable;
 import forestry.factory.recipes.nei.NEIHandlerBottler;
 import forestry.factory.recipes.nei.NEIHandlerCarpenter;
@@ -46,6 +48,8 @@ public class NEIIntegrationConfig implements IConfigureNEI {
 
         CustomOverlayHandler handler = new CustomOverlayHandler(-14, 14, true);
         API.registerGuiOverlayHandler(GuiWorktable.class, handler, "crafting");
+        API.registerGuiOverlayHandler(GuiCarpenter.class, handler, "forestry.carpenter");
+        API.registerGuiOverlayHandler(GuiFabricator.class, handler, "forestry.fabricator");
 
         API.addSubset(
                 "Forestry.Bees.Princesses",

--- a/src/main/java/forestry/core/recipes/nei/SetRecipeCommandHandler.java
+++ b/src/main/java/forestry/core/recipes/nei/SetRecipeCommandHandler.java
@@ -23,18 +23,19 @@ import net.minecraft.nbt.NBTTagList;
  */
 public class SetRecipeCommandHandler {
 
-    private final Class<? extends Container> containerClass;
+    private final Class<? extends Container>[] containerClasses;
     private final Class<? extends Slot> slotClass;
 
-    public SetRecipeCommandHandler(Class<? extends Container> containerClass, Class<? extends Slot> slotClass) {
-        this.containerClass = containerClass;
+    public SetRecipeCommandHandler(Class<? extends Container>[] containerClasses, Class<? extends Slot> slotClass) {
+        this.containerClasses = containerClasses;
         this.slotClass = slotClass;
     }
 
     public void handle(NBTTagCompound data, EntityPlayerMP player) {
         NBTTagList stacks = data.getTagList("stacks", 10);
         Container cont = player.openContainer;
-        if (!containerClass.isInstance(cont)) {
+
+        if (!isContainerClassCorrect(cont)) {
             return;
         }
 
@@ -43,17 +44,20 @@ public class SetRecipeCommandHandler {
             NBTTagCompound itemdata = stacks.getCompoundTagAt(i);
             stmap.put(itemdata.getInteger("slot"), ItemStack.loadItemStackFromNBT(itemdata));
         }
-        for (Object slotobj : cont.inventorySlots) {
-            if (!slotClass.isInstance(slotobj)) {
+        for (Slot slot : cont.inventorySlots) {
+            if (!slotClass.isInstance(slot)) {
                 continue;
             }
+            slot.putStack(stmap.getOrDefault(slot.getSlotIndex(), null));
+        }
+    }
 
-            Slot slot = (Slot) slotobj;
-            if (stmap.containsKey(slot.getSlotIndex())) {
-                slot.putStack(stmap.get(slot.getSlotIndex()));
-            } else {
-                slot.putStack(null);
+    private boolean isContainerClassCorrect(Container cont) {
+        for (Class<? extends Container> containerClass : containerClasses) {
+            if (containerClass.isInstance(cont)) {
+                return true;
             }
         }
+        return false;
     }
 }

--- a/src/main/java/forestry/factory/network/PacketRegistryFactory.java
+++ b/src/main/java/forestry/factory/network/PacketRegistryFactory.java
@@ -9,15 +9,15 @@
 package forestry.factory.network;
 
 import forestry.core.network.PacketRegistry;
+import forestry.factory.network.packets.PacketNEISelect;
 import forestry.factory.network.packets.PacketWorktableMemoryUpdate;
-import forestry.factory.network.packets.PacketWorktableNEISelect;
 import forestry.factory.network.packets.PacketWorktableRecipeUpdate;
 
 public class PacketRegistryFactory extends PacketRegistry {
 
     @Override
     public void registerPackets() {
-        registerServerPacket(new PacketWorktableNEISelect());
+        registerServerPacket(new PacketNEISelect());
 
         registerClientPacket(new PacketWorktableMemoryUpdate());
         registerClientPacket(new PacketWorktableRecipeUpdate());

--- a/src/main/java/forestry/factory/network/packets/PacketNEISelect.java
+++ b/src/main/java/forestry/factory/network/packets/PacketNEISelect.java
@@ -19,27 +19,29 @@ import forestry.core.network.IForestryPacketServer;
 import forestry.core.network.PacketIdServer;
 import forestry.core.network.packets.PacketNBT;
 import forestry.core.recipes.nei.SetRecipeCommandHandler;
+import forestry.factory.gui.ContainerCarpenter;
+import forestry.factory.gui.ContainerFabricator;
 import forestry.factory.gui.ContainerWorktable;
 
-public class PacketWorktableNEISelect extends PacketNBT implements IForestryPacketServer {
+public class PacketNEISelect extends PacketNBT implements IForestryPacketServer {
 
-    private static final SetRecipeCommandHandler worktableNEISelectHandler = new SetRecipeCommandHandler(
-            ContainerWorktable.class,
+    private static final SetRecipeCommandHandler neiSelectHandler = new SetRecipeCommandHandler(
+            new Class[] { ContainerWorktable.class, ContainerCarpenter.class, ContainerFabricator.class },
             SlotCraftMatrix.class);
 
-    public PacketWorktableNEISelect() {}
+    public PacketNEISelect() {}
 
-    public PacketWorktableNEISelect(NBTTagCompound nbttagcompound) {
+    public PacketNEISelect(NBTTagCompound nbttagcompound) {
         super(nbttagcompound);
     }
 
     @Override
     public void onPacketData(DataInputStreamForestry data, EntityPlayerMP player) throws IOException {
-        worktableNEISelectHandler.handle(getTagCompound(), player);
+        neiSelectHandler.handle(getTagCompound(), player);
     }
 
     @Override
     public PacketIdServer getPacketId() {
-        return PacketIdServer.WORKTABLE_NEI_SELECT;
+        return PacketIdServer.NEI_SELECT;
     }
 }

--- a/src/main/java/forestry/factory/recipes/nei/NEIHandlerCarpenter.java
+++ b/src/main/java/forestry/factory/recipes/nei/NEIHandlerCarpenter.java
@@ -11,6 +11,7 @@ package forestry.factory.recipes.nei;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -24,13 +25,14 @@ import codechicken.nei.api.API;
 import forestry.api.recipes.ICarpenterRecipe;
 import forestry.api.recipes.IDescriptiveRecipe;
 import forestry.api.recipes.RecipeManagers;
+import forestry.core.recipes.nei.IGridRecipeHandler;
 import forestry.core.recipes.nei.NEIUtils;
 import forestry.core.recipes.nei.PositionedFluidTank;
 import forestry.core.recipes.nei.RecipeHandlerBase;
 import forestry.core.utils.StringUtil;
 import forestry.factory.gui.GuiCarpenter;
 
-public class NEIHandlerCarpenter extends RecipeHandlerBase {
+public class NEIHandlerCarpenter extends RecipeHandlerBase implements IGridRecipeHandler {
 
     private static Class<? extends GuiContainer> guiClass;
 
@@ -40,11 +42,35 @@ public class NEIHandlerCarpenter extends RecipeHandlerBase {
         API.setGuiOffset(guiClass, 5, 14);
     }
 
+    @Override
+    public int getGridStartX() {
+        return 5;
+    }
+
+    @Override
+    public int getGridStartY() {
+        return 6;
+    }
+
+    @Override
+    public int getGridSpacing() {
+        return 18;
+    }
+
+    @Override
+    public List<PositionedStack> getGridStacks(int recipeIndex) {
+        if (arecipes.get(recipeIndex) instanceof CachedCarpenterRecipe recipe) {
+            return recipe.inputs.subList(0, recipe.ingredientCount);
+        }
+        return Collections.emptyList();
+    }
+
     public class CachedCarpenterRecipe extends CachedBaseRecipe {
 
         public List<PositionedStack> inputs = new ArrayList<>();
         public PositionedFluidTank tank;
         public PositionedStack output;
+        public int ingredientCount;
 
         public CachedCarpenterRecipe(ICarpenterRecipe recipe, boolean genPerms) {
             IDescriptiveRecipe irecipe = recipe.getCraftingGridRecipe();
@@ -78,6 +104,7 @@ public class NEIHandlerCarpenter extends RecipeHandlerBase {
         }
 
         public void setIngredients(int width, int height, Object[] items) {
+            ingredientCount = 0;
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height; y++) {
                     Object item = items[y * width + x];
@@ -89,9 +116,14 @@ public class NEIHandlerCarpenter extends RecipeHandlerBase {
                         continue;
                     }
 
-                    PositionedStack stack = new PositionedStack(item, 5 + x * 18, 6 + y * 18, false);
+                    PositionedStack stack = new PositionedStack(
+                            item,
+                            getGridStartX() + x * getGridSpacing(),
+                            getGridStartY() + y * getGridSpacing(),
+                            false);
                     stack.setMaxSize(1);
                     this.inputs.add(stack);
+                    ingredientCount++;
                 }
             }
         }

--- a/src/main/java/forestry/factory/recipes/nei/NEIHandlerFabricator.java
+++ b/src/main/java/forestry/factory/recipes/nei/NEIHandlerFabricator.java
@@ -11,6 +11,7 @@ package forestry.factory.recipes.nei;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ import codechicken.nei.recipe.GuiRecipe;
 import forestry.api.recipes.IFabricatorRecipe;
 import forestry.api.recipes.IFabricatorSmeltingRecipe;
 import forestry.api.recipes.RecipeManagers;
+import forestry.core.recipes.nei.IGridRecipeHandler;
 import forestry.core.recipes.nei.NEIUtils;
 import forestry.core.recipes.nei.PositionedFluidTank;
 import forestry.core.recipes.nei.RecipeHandlerBase;
@@ -34,7 +36,30 @@ import forestry.core.utils.StringUtil;
 import forestry.factory.gui.GuiFabricator;
 import forestry.factory.recipes.FabricatorSmeltingRecipeManager;
 
-public class NEIHandlerFabricator extends RecipeHandlerBase {
+public class NEIHandlerFabricator extends RecipeHandlerBase implements IGridRecipeHandler {
+
+    @Override
+    public int getGridStartX() {
+        return 62;
+    }
+
+    @Override
+    public int getGridStartY() {
+        return 6;
+    }
+
+    @Override
+    public int getGridSpacing() {
+        return 18;
+    }
+
+    @Override
+    public List<PositionedStack> getGridStacks(int recipeIndex) {
+        if (arecipes.get(recipeIndex) instanceof CachedFabricatorRecipe recipe) {
+            return recipe.inputs.subList(0, recipe.ingredientCount);
+        }
+        return Collections.emptyList();
+    }
 
     public class CachedFabricatorRecipe extends CachedBaseRecipe {
 
@@ -42,6 +67,7 @@ public class NEIHandlerFabricator extends RecipeHandlerBase {
         public PositionedFluidTank tank;
         public List<PositionedStack> inputs = new ArrayList<>();
         public PositionedStack output;
+        public int ingredientCount;
 
         public CachedFabricatorRecipe(IFabricatorRecipe recipe, boolean genPerms) {
             if (recipe.getLiquid() != null) {
@@ -78,6 +104,7 @@ public class NEIHandlerFabricator extends RecipeHandlerBase {
         }
 
         public void setIngredients(int width, int height, Object[] items) {
+            ingredientCount = 0;
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height; y++) {
                     Object item = items[y * width + x];
@@ -89,9 +116,14 @@ public class NEIHandlerFabricator extends RecipeHandlerBase {
                         continue;
                     }
 
-                    PositionedStack stack = new PositionedStack(item, 62 + x * 18, 6 + y * 18, false);
+                    PositionedStack stack = new PositionedStack(
+                            item,
+                            getGridStartX() + x * getGridSpacing(),
+                            getGridStartY() + y * getGridSpacing(),
+                            false);
                     stack.setMaxSize(1);
                     this.inputs.add(stack);
+                    ingredientCount++;
                 }
             }
         }


### PR DESCRIPTION
The NEI fallback overlay handler is extremely laggy for the carpenter. Since both the carpenter and fabricator use a 3x3 crafting grid, similar to the worktable, this PR adapts the worktable overlay handler to work with the carpenter and fabricator.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25009