### PR TITLE
Fix Worktable NEI fill regression

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.9.54:dev")
     api('curse.maven:cofh-lib-220333:2388748')
     compileOnlyApi('com.github.GTNewHorizons:Angelica:2.1.19:api')
-    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.104-GTNH:dev')
+    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.107-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:inventory-tweaks:1.7.1:api')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.57:api')
     compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,4 +1,5 @@
 // Add any additional repositiroes for your dependencies here
 
 repositories {
+    mavenLocal()
 }

--- a/src/main/java/forestry/core/recipes/nei/CustomOverlayHandler.java
+++ b/src/main/java/forestry/core/recipes/nei/CustomOverlayHandler.java
@@ -41,6 +41,11 @@ public class CustomOverlayHandler implements IOverlayHandler {
     }
 
     @Override
+    public boolean requireShiftForOverlayRecipe() {
+        return false;
+    }
+
+    @Override
     public void overlayRecipe(GuiContainer cont, IRecipeHandler recipe, int recipeIndex, boolean shift) {
         int offsetX = 25;
         int offsetY = 6;


### PR DESCRIPTION
Filling the Forestry Worktable recipe from NEI used to work whether or not you held down shift when clicking the overlay button.

This was changed during the 2.9 dev cycle with changes to NEI. This change now explicitly forces shift to be considered held for these handlers.

Incidentally, this is also correct behavior for the recently added Carpenter and Fabricator handlers.

### Before
https://github.com/user-attachments/assets/5ead3698-ce68-4d81-95ad-5ad6db672ec1

### After
https://github.com/user-attachments/assets/7883429c-0e9c-4f70-8c51-afb9b8d1968c
