### PR TITLE
Use extended interface

### DIFF
--- a/src/main/java/forestry/api/apiculture/IArmorApiarist.java
+++ b/src/main/java/forestry/api/apiculture/IArmorApiarist.java
@@ -26,19 +26,6 @@ public interface IArmorApiarist {
     boolean protectEntity(EntityLivingBase entity, ItemStack armor, String cause, boolean doProtect);
 
     /**
-     * Called to determine how many pieces an armor "counts for". For instance, if this returns 4, the single piece will
-     * act as full protection.
-     * 
-     * @param entity Entity being attacked
-     * @param armor  Armor item
-     * @param cause  Optional cause of attack, such as a bee effect identifier
-     * @return Amount of effective protected slots
-     */
-    default int getProtectionCount(EntityLivingBase entity, ItemStack armor, String cause) {
-        return 1;
-    }
-
-    /**
      * Called when the apiarist's armor acts as protection against an attack.
      *
      * @param player    Player being attacked

--- a/src/main/java/forestry/api/apiculture/IArmorApiaristMulti.java
+++ b/src/main/java/forestry/api/apiculture/IArmorApiaristMulti.java
@@ -1,0 +1,20 @@
+package forestry.api.apiculture;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+public interface IArmorApiaristMulti extends IArmorApiarist {
+
+    /**
+     * Called to determine how many pieces an armor "counts for". For instance, if this returns 4, the single piece will
+     * act as full protection.
+     *
+     * @param entity Entity being attacked
+     * @param armor  Armor item
+     * @param cause  Optional cause of attack, such as a bee effect identifier
+     * @return Amount of effective protected slots
+     */
+    default int getProtectionCount(EntityLivingBase entity, ItemStack armor, String cause) {
+        return 1;
+    }
+}

--- a/src/main/java/forestry/apiculture/ArmorApiaristHelper.java
+++ b/src/main/java/forestry/apiculture/ArmorApiaristHelper.java
@@ -10,10 +10,12 @@ package forestry.apiculture;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import forestry.api.apiculture.IArmorApiarist;
 import forestry.api.apiculture.IArmorApiaristHelper;
+import forestry.api.apiculture.IArmorApiaristMulti;
 
 public class ArmorApiaristHelper implements IArmorApiaristHelper {
 
@@ -40,7 +42,9 @@ public class ArmorApiaristHelper implements IArmorApiaristHelper {
         for (int i = 1; i <= 4; i++) {
             ItemStack armorItem = entity.getEquipmentInSlot(i);
             if (isArmorApiarist(armorItem, entity, cause, doProtect)) {
-                count += ((IArmorApiarist) armorItem.getItem()).getProtectionCount(entity, armorItem, cause);
+                Item item = armorItem.getItem();
+                if (item instanceof IArmorApiaristMulti am) count += am.getProtectionCount(entity, armorItem, cause);
+                else count++;
             }
         }
 


### PR DESCRIPTION
## Summary
Add extended interface IArmorApiaristMulti and move getProtectionCount into it in order to preserve some asm transformers discovered in https://github.com/GTNewHorizons/ForestryMC/pull/122. Requires an immediate update to GT5U to prevent issues.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
