### PR TITLE
Fix Japanese block names showing as unlocalized .name keys

### DIFF
--- a/src/main/resources/assets/forestry/lang/ja_JP.lang
+++ b/src/main/resources/assets/forestry/lang/ja_JP.lang
@@ -501,10 +501,10 @@ tile.for.log1=原木
 tile.for.log2=原木
 tile.for.log3=原木
 tile.for.log4=原木
-tile.for.planks=木材
+tile.for.planks.name=木材
 tile.for.slabs1=木材ハーフブロック
 tile.for.slabs2=木材ハーフブロック
-tile.for.fences=フェンス
+tile.for.fences.name=フェンス
 tile.harvester.0=伐採機
 tile.harvester.1=収穫機
 tile.harvester.2=ゴムの木収穫機
@@ -757,9 +757,11 @@ tile.candle.dyed.stump=Unlit Dyed Candle
 tile.candle.lit=Lit Candle
 tile.candle.dyed.lit=Lit Dyed Candle
 tile.stump.0=Candle Stump
-tile.for.apiculture.0=Apiary
-tile.for.apiculture.1=Apiarist's Chest
-tile.for.apiculture.2=Bee House
+tile.for.apiculture.name=養蜂箱
+tile.for.apiculture.0.name=養蜂箱
+tile.for.apicultureChest.name=養蜂家のチェスト
+tile.for.apicultureChest.0.name=養蜂家のチェスト
+tile.for.apiculture.2.name=ビーハウス
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -808,7 +810,7 @@ tile.log=Wood
 tile.planks=Wood Planks
 tile.slab=Wood Slab
 tile.fences=Fence
-tile.for.stairs=Stairs
+tile.for.stairs.name=階段
 wood.0=Larch
 wood.1=Teak
 wood.2=Acacia
@@ -833,7 +835,8 @@ wood.20=Pine
 wood.21=Plum
 wood.22=Maple
 wood.23=Citrus
-tile.for.arboriculture.0=Arborist's Chest
+tile.for.arboriculture.name=樹医のチェスト
+tile.for.arboriculture.0.name=樹医のチェスト
 
 ####################
 # FARMING
@@ -906,7 +909,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=鱗翅類学者のチェスト
+tile.for.lepidopterology.0.name=鱗翅類学者のチェスト
 
 ####################
 # MAIL


### PR DESCRIPTION
## What

Fixes Japanese block names displaying as raw unlocalized keys such as `Apiary.name` / `Bee House.name`.

## Why

`ja_JP.lang` still contains old-format entries without the `.name` suffix, e.g.:

```
tile.for.apiculture.0=Apiary
```

The vanilla 1.7.10 display-name lookup (`getUnlocalizedNameInefficiently`) first translates the raw unlocalized key, then appends `.name` and translates again. When the old-format key exists, the first lookup succeeds and returns `Apiary`, so the second lookup becomes `Apiary.name`, which does not exist — the block ends up displayed as `Apiary.name`.

This also prevents external lang overrides (e.g. the GTNH-Translations pack, which provides correct `tile.for.apiculture.0.name=養蜂箱` via TX Loader) from ever taking effect.

Affected old-format keys in `ja_JP.lang`: `tile.for.planks`, `tile.for.fences`, `tile.for.stairs`, `tile.for.apiculture.0/.1/.2`, `tile.for.arboriculture.0`, `tile.for.lepidopterology.0`.

## How

Converted these entries to the `.name` key format used by `en_US.lang`, with the Japanese translations taken from GTNH-Translations (ParaTranz).

## Testing

Verified on GTNH 2.8.4 (Forestry 4.10.17) by patching the jar's `ja_JP.lang` with this file — the `ja_JP.lang` in the 4.10.17 jar is identical to current master. Apiary / Bee House / Alveary-related chests now display their Japanese names instead of `*.name`.

Note: several other languages (`es_*`, `pl_PL`, `cs_CZ`, `et_EE`, `fi_FI`, `he_IL`, `nl_NL`, `no_NO`, `pt_PT`) contain the same old-format poison keys and likely show the same `.name` symptom; this PR only fixes Japanese.



Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26145
