### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/forestry/mail/LetterProperties.java
+++ b/src/main/java/forestry/mail/LetterProperties.java
@@ -25,16 +25,22 @@ import forestry.plugins.PluginMail;
 public class LetterProperties {
 
     private enum State {
+
         FRESH,
         STAMPED,
         OPENED,
-        EMPTIED
+        EMPTIED;
+
+        public static final State[] VALUES = values();
     }
 
     private enum Size {
+
         EMPTY,
         SMALL,
-        BIG
+        BIG;
+
+        public static final Size[] VALUES = values();
     }
 
     public static ItemStack createStampedLetterStack(ILetter letter) {
@@ -98,8 +104,8 @@ public class LetterProperties {
 
     @SuppressWarnings("unchecked")
     public static void getSubItems(Item item, CreativeTabs tab, @SuppressWarnings("rawtypes") List list) {
-        for (State state : State.values()) {
-            for (Size size : Size.values()) {
+        for (State state : State.VALUES) {
+            for (Size size : Size.VALUES) {
                 int meta = encodeMeta(state, size);
                 ItemStack letter = new ItemStack(item, 1, meta);
                 list.add(letter);
@@ -117,7 +123,7 @@ public class LetterProperties {
 
     private static State getState(int meta) {
         int ordinal = meta & 0x0f;
-        State[] values = State.values();
+        State[] values = State.VALUES;
         if (ordinal >= values.length) {
             ordinal = 0;
         }
@@ -126,7 +132,7 @@ public class LetterProperties {
 
     private static Size getSize(int meta) {
         int ordinal = meta >> 4;
-        Size[] values = Size.values();
+        Size[] values = Size.VALUES;
         if (ordinal >= values.length) {
             ordinal = 0;
         }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge