### PR TITLE
More enum `.values()` caching

### DIFF
--- a/src/main/java/forestry/arboriculture/blocks/BlockSlab.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockSlab.java
@@ -72,7 +72,7 @@ public class BlockSlab extends net.minecraft.block.BlockSlab implements IWoodTyp
     @SideOnly(Side.CLIENT)
     @Override
     public IIcon getIcon(int side, int meta) {
-        return IconProviderWood.getPlankIcon(EnumWoodType.values()[meta]);
+        return IconProviderWood.getPlankIcon(EnumWoodType.VALUES[meta]);
     }
 
     @Override


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Apparently this enum call was forgotten and still shows in profiles. Fixed.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
