### PR TITLE
Fix other-language block names showing as unlocalized .name keys

### DIFF
--- a/src/main/resources/assets/forestry/lang/cs_CZ.lang
+++ b/src/main/resources/assets/forestry/lang/cs_CZ.lang
@@ -708,9 +708,11 @@ tile.candle.dyed.stump=Unlit Dyed Candle
 tile.candle.lit=Lit Candle
 tile.candle.dyed.lit=Lit Dyed Candle
 tile.stump.0=Candle Stump
-tile.for.apiculture.0=Apiary
-tile.for.apiculture.1=Apiarist's Chest
-tile.for.apiculture.2=Bee House
+tile.for.apiculture.name=Apiary
+tile.for.apiculture.0.name=Apiary
+tile.for.apicultureChest.name=Apiarist's Chest
+tile.for.apicultureChest.0.name=Apiarist's Chest
+tile.for.apiculture.2.name=Bee House
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -759,7 +761,7 @@ tile.log=Wood
 tile.planks=Wood Planks
 tile.slab=Wood Slab
 tile.fences=Fence
-tile.for.stairs=Stairs
+tile.for.stairs.name=Stairs
 wood.0=Larch
 wood.1=Teak
 wood.2=Acacia
@@ -784,7 +786,8 @@ wood.20=Pine
 wood.21=Plum
 wood.22=Maple
 wood.23=Citrus
-tile.for.arboriculture.0=Arborist's Chest
+tile.for.arboriculture.name=Arborist's Chest
+tile.for.arboriculture.0.name=Arborist's Chest
 
 ####################
 # FARMING
@@ -857,7 +860,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=Lepidopterist's Chest
+tile.for.lepidopterology.0.name=Lepidopterist's Chest
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/es_AR.lang
+++ b/src/main/resources/assets/forestry/lang/es_AR.lang
@@ -685,9 +685,11 @@ tile.alveary.6=Estabilizador de Enjambre
 tile.alveary.7=Tamiz para Enjambre
 tile.candle.0=Vela
 tile.stump.0=Tocуn de Vela
-tile.for.apiculture.0=Apiario
-tile.for.apiculture.1=Cofre de Apicultor
-tile.for.apiculture.2=Casa de Abejas
+tile.for.apiculture.name=Apiario
+tile.for.apiculture.0.name=Apiario
+tile.for.apicultureChest.name=Cofre de Apicultor
+tile.for.apicultureChest.0.name=Cofre de Apicultor
+tile.for.apiculture.2.name=Casa de Abejas
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -736,7 +738,7 @@ tile.log=Madera
 tile.planks=Tablones de Madera
 tile.slab=Losa de Madera
 tile.fences=Cerca
-tile.for.stairs=Escaleras
+tile.for.stairs.name=Escaleras
 wood.0=Alerce
 wood.1=Teca
 wood.2=Acacia
@@ -761,7 +763,8 @@ wood.20=Pino
 wood.21=Ciruela
 wood.22=Arce
 wood.23=Citrus
-tile.for.arboriculture.0=Cofre de Arborista
+tile.for.arboriculture.name=Cofre de Arborista
+tile.for.arboriculture.0.name=Cofre de Arborista
 
 ####################
 # FARMING
@@ -834,7 +837,8 @@ item.butterfly=Mariposa
 item.moth=Polilla
 item.flutterlyzer=Mariposanalizador
 storage.backpack.lepidopterist=Mochila de Lepidopterуlogo
-tile.for.lepidopterology.0=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.name=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.0.name=Cofre de Lepidopterуlogo
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/es_ES.lang
+++ b/src/main/resources/assets/forestry/lang/es_ES.lang
@@ -692,9 +692,11 @@ tile.alveary.6=Estabilizador de Enjambre
 tile.alveary.7=Tamiz para Enjambre
 tile.candle.0=Vela
 tile.stump.0=Tocуn de Vela
-tile.for.apiculture.0=Apiario
-tile.for.apiculture.1=Cofre de Apicultor
-tile.for.apiculture.2=Casa de Abejas
+tile.for.apiculture.name=Apiario
+tile.for.apiculture.0.name=Apiario
+tile.for.apicultureChest.name=Cofre de Apicultor
+tile.for.apicultureChest.0.name=Cofre de Apicultor
+tile.for.apiculture.2.name=Casa de Abejas
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -743,7 +745,7 @@ tile.log=Madera
 tile.planks=Tablones de Madera
 tile.slab=Losa de Madera
 tile.fences=Cerca
-tile.for.stairs=Escaleras
+tile.for.stairs.name=Escaleras
 wood.0=Alerce
 wood.1=Teca
 wood.2=Acacia
@@ -768,7 +770,8 @@ wood.20=Pino
 wood.21=Ciruela
 wood.22=Arce
 wood.23=Citrus
-tile.for.arboriculture.0=Cofre de Arborista
+tile.for.arboriculture.name=Cofre de Arborista
+tile.for.arboriculture.0.name=Cofre de Arborista
 
 ####################
 # FARMING
@@ -841,7 +844,8 @@ item.butterfly=Mariposa
 item.moth=Polilla
 item.flutterlyzer=Mariposanalizador
 storage.backpack.lepidopterist=Mochila de Lepidopterуlogo
-tile.for.lepidopterology.0=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.name=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.0.name=Cofre de Lepidopterуlogo
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/es_MX.lang
+++ b/src/main/resources/assets/forestry/lang/es_MX.lang
@@ -685,9 +685,11 @@ tile.alveary.6=Estabilizador de Enjambre
 tile.alveary.7=Tamiz para Enjambre
 tile.candle.0=Vela
 tile.stump.0=Tocуn de Vela
-tile.for.apiculture.0=Apiario
-tile.for.apiculture.1=Cofre de Apicultor
-tile.for.apiculture.2=Casa de Abejas
+tile.for.apiculture.name=Apiario
+tile.for.apiculture.0.name=Apiario
+tile.for.apicultureChest.name=Cofre de Apicultor
+tile.for.apicultureChest.0.name=Cofre de Apicultor
+tile.for.apiculture.2.name=Casa de Abejas
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -736,7 +738,7 @@ tile.log=Madera
 tile.planks=Tablones de Madera
 tile.slab=Losa de Madera
 tile.fences=Cerca
-tile.for.stairs=Escaleras
+tile.for.stairs.name=Escaleras
 wood.0=Alerce
 wood.1=Teca
 wood.2=Acacia
@@ -761,7 +763,8 @@ wood.20=Pino
 wood.21=Ciruela
 wood.22=Arce
 wood.23=Citrus
-tile.for.arboriculture.0=Cofre de Arborista
+tile.for.arboriculture.name=Cofre de Arborista
+tile.for.arboriculture.0.name=Cofre de Arborista
 
 ####################
 # FARMING
@@ -834,7 +837,8 @@ item.butterfly=Mariposa
 item.moth=Polilla
 item.flutterlyzer=Mariposanalizador
 storage.backpack.lepidopterist=Mochila de Lepidopterуlogo
-tile.for.lepidopterology.0=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.name=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.0.name=Cofre de Lepidopterуlogo
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/es_UY.lang
+++ b/src/main/resources/assets/forestry/lang/es_UY.lang
@@ -685,9 +685,11 @@ tile.alveary.6=Estabilizador de Enjambre
 tile.alveary.7=Tamiz para Enjambre
 tile.candle.0=Vela
 tile.stump.0=Tocуn de Vela
-tile.for.apiculture.0=Apiario
-tile.for.apiculture.1=Cofre de Apicultor
-tile.for.apiculture.2=Casa de Abejas
+tile.for.apiculture.name=Apiario
+tile.for.apiculture.0.name=Apiario
+tile.for.apicultureChest.name=Cofre de Apicultor
+tile.for.apicultureChest.0.name=Cofre de Apicultor
+tile.for.apiculture.2.name=Casa de Abejas
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -736,7 +738,7 @@ tile.log=Madera
 tile.planks=Tablones de Madera
 tile.slab=Losa de Madera
 tile.fences=Cerca
-tile.for.stairs=Escaleras
+tile.for.stairs.name=Escaleras
 wood.0=Alerce
 wood.1=Teca
 wood.2=Acacia
@@ -761,7 +763,8 @@ wood.20=Pino
 wood.21=Ciruela
 wood.22=Arce
 wood.23=Citrus
-tile.for.arboriculture.0=Cofre de Arborista
+tile.for.arboriculture.name=Cofre de Arborista
+tile.for.arboriculture.0.name=Cofre de Arborista
 
 ####################
 # FARMING
@@ -834,7 +837,8 @@ item.butterfly=Mariposa
 item.moth=Polilla
 item.flutterlyzer=Mariposanalizador
 storage.backpack.lepidopterist=Mochila de Lepidopterуlogo
-tile.for.lepidopterology.0=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.name=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.0.name=Cofre de Lepidopterуlogo
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/es_VE.lang
+++ b/src/main/resources/assets/forestry/lang/es_VE.lang
@@ -685,9 +685,11 @@ tile.alveary.6=Estabilizador de Enjambre
 tile.alveary.7=Tamiz para Enjambre
 tile.candle.0=Vela
 tile.stump.0=Tocуn de Vela
-tile.for.apiculture.0=Apiario
-tile.for.apiculture.1=Cofre de Apicultor
-tile.for.apiculture.2=Casa de Abejas
+tile.for.apiculture.name=Apiario
+tile.for.apiculture.0.name=Apiario
+tile.for.apicultureChest.name=Cofre de Apicultor
+tile.for.apicultureChest.0.name=Cofre de Apicultor
+tile.for.apiculture.2.name=Casa de Abejas
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -736,7 +738,7 @@ tile.log=Madera
 tile.planks=Tablones de Madera
 tile.slab=Losa de Madera
 tile.fences=Cerca
-tile.for.stairs=Escaleras
+tile.for.stairs.name=Escaleras
 wood.0=Alerce
 wood.1=Teca
 wood.2=Acacia
@@ -761,7 +763,8 @@ wood.20=Pino
 wood.21=Ciruela
 wood.22=Arce
 wood.23=Citrus
-tile.for.arboriculture.0=Cofre de Arborista
+tile.for.arboriculture.name=Cofre de Arborista
+tile.for.arboriculture.0.name=Cofre de Arborista
 
 ####################
 # FARMING
@@ -834,7 +837,8 @@ item.butterfly=Mariposa
 item.moth=Polilla
 item.flutterlyzer=Mariposanalizador
 storage.backpack.lepidopterist=Mochila de Lepidopterуlogo
-tile.for.lepidopterology.0=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.name=Cofre de Lepidopterуlogo
+tile.for.lepidopterology.0.name=Cofre de Lepidopterуlogo
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/et_EE.lang
+++ b/src/main/resources/assets/forestry/lang/et_EE.lang
@@ -699,9 +699,11 @@ tile.candle.dyed.stump=Unlit Dyed Candle
 tile.candle.lit=Lit Candle
 tile.candle.dyed.lit=Lit Dyed Candle
 tile.stump.0=Candle Stump
-tile.for.apiculture.0=Apiary
-tile.for.apiculture.1=Apiarist's Chest
-tile.for.apiculture.2=Bee House
+tile.for.apiculture.name=Apiary
+tile.for.apiculture.0.name=Apiary
+tile.for.apicultureChest.name=Apiarist's Chest
+tile.for.apicultureChest.0.name=Apiarist's Chest
+tile.for.apiculture.2.name=Bee House
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -750,7 +752,7 @@ tile.log=Wood
 tile.planks=Wood Planks
 tile.slab=Wood Slab
 tile.fences=Fence
-tile.for.stairs=Stairs
+tile.for.stairs.name=Stairs
 wood.0=Larch
 wood.1=Teak
 wood.2=Acacia
@@ -775,7 +777,8 @@ wood.20=Pine
 wood.21=Plum
 wood.22=Maple
 wood.23=Citrus
-tile.for.arboriculture.0=Arborist's Chest
+tile.for.arboriculture.name=Arborist's Chest
+tile.for.arboriculture.0.name=Arborist's Chest
 
 ####################
 # FARMING
@@ -848,7 +851,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=Lepidopterist's Chest
+tile.for.lepidopterology.0.name=Lepidopterist's Chest
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/fi_FI.lang
+++ b/src/main/resources/assets/forestry/lang/fi_FI.lang
@@ -614,9 +614,11 @@ tile.candle.dyed.stump=Unlit Dyed Candle
 tile.candle.lit=Lit Candle
 tile.candle.dyed.lit=Lit Dyed Candle
 tile.stump.0=Candle Stump
-tile.for.apiculture.0=Apiary
-tile.for.apiculture.1=Apiarist's Chest
-tile.for.apiculture.2=Bee House
+tile.for.apiculture.name=Apiary
+tile.for.apiculture.0.name=Apiary
+tile.for.apicultureChest.name=Apiarist's Chest
+tile.for.apicultureChest.0.name=Apiarist's Chest
+tile.for.apiculture.2.name=Bee House
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -665,7 +667,7 @@ tile.log=Wood
 tile.planks=Wood Planks
 tile.slab=Wood Slab
 tile.fences=Fence
-tile.for.stairs=Stairs
+tile.for.stairs.name=Stairs
 wood.0=Larch
 wood.1=Teak
 wood.2=Acacia
@@ -690,7 +692,8 @@ wood.20=Pine
 wood.21=Plum
 wood.22=Maple
 wood.23=Citrus
-tile.for.arboriculture.0=Arborist's Chest
+tile.for.arboriculture.name=Arborist's Chest
+tile.for.arboriculture.0.name=Arborist's Chest
 
 ####################
 # FARMING
@@ -763,7 +766,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=Lepidopterist's Chest
+tile.for.lepidopterology.0.name=Lepidopterist's Chest
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/he_IL.lang
+++ b/src/main/resources/assets/forestry/lang/he_IL.lang
@@ -690,9 +690,11 @@ tile.candle.dyed.stump=Unlit Dyed Candle
 tile.candle.lit=Lit Candle
 tile.candle.dyed.lit=Lit Dyed Candle
 tile.stump.0=Candle Stump
-tile.for.apiculture.0=Apiary
-tile.for.apiculture.1=Apiarist's Chest
-tile.for.apiculture.2=Bee House
+tile.for.apiculture.name=Apiary
+tile.for.apiculture.0.name=Apiary
+tile.for.apicultureChest.name=Apiarist's Chest
+tile.for.apicultureChest.0.name=Apiarist's Chest
+tile.for.apiculture.2.name=Bee House
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -741,7 +743,7 @@ tile.log=Wood
 tile.planks=Wood Planks
 tile.slab=Wood Slab
 tile.fences=Fence
-tile.for.stairs=Stairs
+tile.for.stairs.name=Stairs
 wood.0=Larch
 wood.1=Teak
 wood.2=Acacia
@@ -766,7 +768,8 @@ wood.20=Pine
 wood.21=Plum
 wood.22=Maple
 wood.23=Citrus
-tile.for.arboriculture.0=Arborist's Chest
+tile.for.arboriculture.name=Arborist's Chest
+tile.for.arboriculture.0.name=Arborist's Chest
 
 ####################
 # FARMING
@@ -839,7 +842,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=Lepidopterist's Chest
+tile.for.lepidopterology.0.name=Lepidopterist's Chest
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/it_IT.lang
+++ b/src/main/resources/assets/forestry/lang/it_IT.lang
@@ -489,10 +489,10 @@ tile.for.log1=Legna
 tile.for.log2=Legna
 tile.for.log3=Legna
 tile.for.log4=Legna
-tile.for.planks=Assi di legno
+tile.for.planks.name=Assi di legno
 tile.for.slabs1=Lastra di legno
 tile.for.slabs2=Lastra di legno
-tile.for.fences=Staccionata
+tile.for.fences.name=Staccionata
 tile.harvester.0=Taglialegna
 tile.harvester.1=Combinatore
 tile.harvester.2=Raccogli-albero della gomma
@@ -741,7 +741,7 @@ tile.log=Wood
 tile.planks=Wood Planks
 tile.slab=Wood Slab
 tile.fences=Fence
-tile.for.stairs=Stairs
+tile.for.stairs.name=Stairs
 wood.0=Larch
 wood.1=Teak
 wood.2=Acacia
@@ -766,7 +766,8 @@ wood.20=Pine
 wood.21=Plum
 wood.22=Maple
 wood.23=Citrus
-tile.for.arboriculture.0=Arborist's Chest
+tile.for.arboriculture.name=Arborist's Chest
+tile.for.arboriculture.0.name=Arborist's Chest
 
 ####################
 # FARMING
@@ -836,7 +837,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=Lepidopterist's Chest
+tile.for.lepidopterology.0.name=Lepidopterist's Chest
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/nl_NL.lang
+++ b/src/main/resources/assets/forestry/lang/nl_NL.lang
@@ -709,9 +709,11 @@ tile.candle.dyed.stump=Unlit Dyed Candle
 tile.candle.lit=Lit Candle
 tile.candle.dyed.lit=Lit Dyed Candle
 tile.stump.0=Candle Stump
-tile.for.apiculture.0=Apiary
-tile.for.apiculture.1=Apiarist's Chest
-tile.for.apiculture.2=Bee House
+tile.for.apiculture.name=Apiary
+tile.for.apiculture.0.name=Apiary
+tile.for.apicultureChest.name=Apiarist's Chest
+tile.for.apicultureChest.0.name=Apiarist's Chest
+tile.for.apiculture.2.name=Bee House
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -760,7 +762,7 @@ tile.log=Hout
 tile.planks=houten planken
 tile.slab=houten plaat
 tile.fences=houten hek
-tile.for.stairs=houten treden
+tile.for.stairs.name=houten treden
 wood.0=Lariks
 wood.1=Teak
 wood.2=Acacia
@@ -857,7 +859,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=Lepidopterist's Chest
+tile.for.lepidopterology.0.name=Lepidopterist's Chest
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/no_NO.lang
+++ b/src/main/resources/assets/forestry/lang/no_NO.lang
@@ -710,9 +710,11 @@ tile.candle.dyed.stump=Unlit Dyed Candle
 tile.candle.lit=Lit Candle
 tile.candle.dyed.lit=Lit Dyed Candle
 tile.stump.0=Candle Stump
-tile.for.apiculture.0=Apiary
-tile.for.apiculture.1=Apiarist's Chest
-tile.for.apiculture.2=Bee House
+tile.for.apiculture.name=Apiary
+tile.for.apiculture.0.name=Apiary
+tile.for.apicultureChest.name=Apiarist's Chest
+tile.for.apicultureChest.0.name=Apiarist's Chest
+tile.for.apiculture.2.name=Bee House
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -761,7 +763,7 @@ tile.log=Wood
 tile.planks=Wood Planks
 tile.slab=Wood Slab
 tile.fences=Fence
-tile.for.stairs=Stairs
+tile.for.stairs.name=Stairs
 wood.0=Larch
 wood.1=Teak
 wood.2=Acacia
@@ -786,7 +788,8 @@ wood.20=Pine
 wood.21=Plum
 wood.22=Maple
 wood.23=Citrus
-tile.for.arboriculture.0=Arborist's Chest
+tile.for.arboriculture.name=Arborist's Chest
+tile.for.arboriculture.0.name=Arborist's Chest
 
 ####################
 # FARMING
@@ -859,7 +862,8 @@ item.butterfly=Butterfly
 item.moth=Moth
 item.flutterlyzer=Flutterlyzer
 storage.backpack.lepidopterist=Lepidopterist's Backpack
-tile.for.lepidopterology.0=Lepidopterist's Chest
+tile.for.lepidopterology.name=Lepidopterist's Chest
+tile.for.lepidopterology.0.name=Lepidopterist's Chest
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/pl_PL.lang
+++ b/src/main/resources/assets/forestry/lang/pl_PL.lang
@@ -695,9 +695,11 @@ tile.alveary.6=Stabilizator Wielkiego Ula
 tile.alveary.7=Sito Wielkiego Ula
 tile.candle.0=świeca
 tile.stump.0=Postawa świecy
-tile.for.apiculture.0=Ul
-tile.for.apiculture.1=Skrzynia pszczelarza
-tile.for.apiculture.2=Dom pszczół
+tile.for.apiculture.name=Ul
+tile.for.apiculture.0.name=Ul
+tile.for.apicultureChest.name=Skrzynia pszczelarza
+tile.for.apicultureChest.0.name=Skrzynia pszczelarza
+tile.for.apiculture.2.name=Dom pszczół
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -746,7 +748,7 @@ tile.log=Drewno
 tile.planks=Drewniane Deski
 tile.slab=Drewniana Półpłytka
 tile.fences=Płotek
-tile.for.stairs=Schody
+tile.for.stairs.name=Schody
 wood.0=Modrzew
 wood.1=Tek
 wood.2=Akacja
@@ -771,7 +773,8 @@ wood.20=Sosna
 wood.21=Śliwka
 wood.22=Klon
 wood.23=Cytrus
-tile.for.arboriculture.0=Skrzynia Drzewiarza
+tile.for.arboriculture.name=Skrzynia Drzewiarza
+tile.for.arboriculture.0.name=Skrzynia Drzewiarza
 
 ####################
 # FARMING
@@ -844,7 +847,8 @@ item.butterfly=Motyl
 item.moth=Ćma
 item.flutterlyzer=Motyloanalizer
 storage.backpack.lepidopterist=Plecak Entomolog'a
-tile.for.lepidopterology.0=Skrzynia Entomolog'a
+tile.for.lepidopterology.name=Skrzynia Entomolog'a
+tile.for.lepidopterology.0.name=Skrzynia Entomolog'a
 
 ####################
 # MAIL

--- a/src/main/resources/assets/forestry/lang/pt_PT.lang
+++ b/src/main/resources/assets/forestry/lang/pt_PT.lang
@@ -679,9 +679,11 @@ tile.alveary.6=Estabilizador de Colmeia
 tile.alveary.7=Peneira para Colmeia
 tile.candle.0=Vela
 tile.stump.0=Cepo de Vela
-tile.for.apiculture.0=Apiбrio
-tile.for.apiculture.1=Baъ de Apicultor
-tile.for.apiculture.2=Ninho para Abelhas
+tile.for.apiculture.name=Apiбrio
+tile.for.apiculture.0.name=Apiбrio
+tile.for.apicultureChest.name=Baъ de Apicultor
+tile.for.apicultureChest.0.name=Baъ de Apicultor
+tile.for.apiculture.2.name=Ninho para Abelhas
 item.for.beeQueenGE.name=Unknown Queen
 
 ####################
@@ -730,7 +732,7 @@ tile.log=Wood
 tile.planks=Tбbuas de Madeira
 tile.slab=Degrau de Madeira
 tile.fences=Cerca
-tile.for.stairs=Escadas
+tile.for.stairs.name=Escadas
 wood.0=Lariзo
 wood.1=Teca
 wood.2=Acбcia
@@ -827,7 +829,8 @@ item.butterfly=Borboleta
 item.moth=Mariposa
 item.flutterlyzer=Borboletizador
 storage.backpack.lepidopterist=Mala de Lepidopterologista
-tile.for.lepidopterology.0=Baъ de Lepidopterologista
+tile.for.lepidopterology.name=Baъ de Lepidopterologista
+tile.for.lepidopterology.0.name=Baъ de Lepidopterologista
 
 ####################
 # MAIL


### PR DESCRIPTION
## What

Follow-up to #128 (Japanese fix). Fixes the same class of bug in `cs_CZ`, `es_AR`, `es_ES`, `es_MX`, `es_UY`, `es_VE`, `et_EE`, `fi_FI`, `he_IL`, `it_IT`, `nl_NL`, `no_NO`, `pl_PL` and `pt_PT`, which all contain old-format lang entries without the `.name` suffix, e.g.:

```
tile.for.apiculture.0=Apiary
```

## Why

As noted in #128's description, several other bundled languages contain the same old-format poison keys. The vanilla 1.7.10 display-name lookup (`getUnlocalizedNameInefficiently`) first translates the raw unlocalized key, then appends `.name` and translates again. When the old-format key exists, the first lookup succeeds, so the second lookup becomes a non-existent key (e.g. `Apiary.name`) — the block displays as the literal key text. This also blocks external lang overrides (e.g. GTNH-Translations via TX Loader) from taking effect, since they only provide the correct `.name`-suffixed keys.

Affected old-format keys (mirroring #128): `tile.for.planks`, `tile.for.fences`, `tile.for.stairs`, `tile.for.apiculture.0/.1/.2`, `tile.for.arboriculture.0`, `tile.for.lepidopterology.0`.

## How

Renamed these entries to the `.name` key format used by `en_US.lang` (same key mapping used in #128, e.g. `tile.for.apiculture.1` → `tile.for.apicultureChest.name` + `tile.for.apicultureChest.0.name`), keeping each language's existing value unchanged. This is a pure key-format fix — no translation text was altered, so languages that already had a real native translation keep it, and languages where the old entry was just an untranslated English placeholder now correctly fall back to English instead of showing the raw key.

Note: a few pre-existing mojibake/encoding issues in some of these files (e.g. `pt_PT`, `es_*`) were left untouched — out of scope for this fix.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#26315